### PR TITLE
ci: disable zizmor advanced security for private repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           version: 'v1.23.1'
-          # advanced-security: false  # must be false for private repo
+          advanced-security: false  # must be false for private repo
 
   validate-renovate-config:
     name: Validate Renovate config


### PR DESCRIPTION
- enable `advanced-security: false` in the zizmor action for private repository compatibility
