### PR TITLE
docs: add quick setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 [![prek](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/j178/prek/master/docs/assets/badge-v0.json)](https://github.com/j178/prek)
 
 A repository for distributing a reproducible and maintainable shared Ubuntu environment for ISSL.
+
+## Quick Setup
+
+Bootstrap the ISSL Ubuntu environment with a single command:
+
+```bash
+bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/latest/download/setup.sh)
+```
+
+To pin the setup to a fixed release instead of `latest`, replace `latest` with a release tag such as `v0.1.1`:
+
+```bash
+bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/download/v0.1.1/setup.sh)
+```


### PR DESCRIPTION
- add the recommended quick setup command using the latest release asset
- document how to pin the setup script to a fixed release tag