### PR TITLE
refactor: manage common packages with home-manager

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,6 @@ jobs:
         run: |
           tmpdir="$(mktemp -d)"
           {
-            echo "profile_path=${tmpdir}/profile"
             echo "home_dir=${tmpdir}/home"
             echo "config_dir=${tmpdir}/home/.config"
             echo "data_dir=${tmpdir}/home/.local/share"
@@ -64,7 +63,6 @@ jobs:
       - name: Run apply.sh
         shell: bash
         env:
-          PROFILE_PATH: ${{ steps.test-env.outputs.profile_path }}
           HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
           CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
           DATA_DIR: ${{ steps.test-env.outputs.data_dir }}
@@ -76,15 +74,19 @@ jobs:
             XDG_CONFIG_HOME="${CONFIG_DIR}" \
             XDG_DATA_HOME="${DATA_DIR}" \
             XDG_STATE_HOME="${STATE_DIR}" \
-            NIX_PROFILE_PATH="${PROFILE_PATH}" \
             GIT_USER_NAME="ISSL Test User" \
             GIT_USER_EMAIL="issl-test@example.com" \
             bash ./scripts/apply.sh
 
+      - name: Add Home Manager profile to PATH
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+        run: echo "${HOME_DIR}/.nix-profile/bin" >> "${GITHUB_PATH}"
+
       - name: Test git setup
         shell: bash
         env:
-          PROFILE_PATH: ${{ steps.test-env.outputs.profile_path }}
           HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
           CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
         run: ./tests/test-git.sh
@@ -92,5 +94,5 @@ jobs:
       - name: Test uv setup
         shell: bash
         env:
-          PROFILE_PATH: ${{ steps.test-env.outputs.profile_path }}
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
         run: ./tests/test-uv.sh

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,6 @@
           inherit pkgs;
           modules = [
             ./home-modules/common.nix
-            ./home-modules/git.nix
             {
               home = {
                 inherit username homeDirectory;

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           modules = [
+            ./home-modules/common.nix
             ./home-modules/git.nix
             {
               home = {
@@ -48,18 +49,8 @@
     {
       packages = forAllSystems (
         system:
-        let
-          pkgs = mkPkgs system;
-          packageSets = {
-            common = import ./packages/common.nix { inherit pkgs; };
-          };
-          issl-common = import ./profiles/issl-common.nix {
-            inherit pkgs packageSets;
-          };
-        in
         {
-          default = issl-common;
-          inherit issl-common;
+          default = home-manager.packages.${system}.home-manager;
           inherit (home-manager.packages.${system}) home-manager;
         }
       );
@@ -75,7 +66,6 @@
         system:
         {
           home = self.homeConfigurations."issl-common-${system}".activationPackage;
-          package = self.packages.${system}.issl-common;
         }
       );
     };

--- a/home-modules/common.nix
+++ b/home-modules/common.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.git
+    pkgs.uv
+  ];
+}

--- a/home-modules/common.nix
+++ b/home-modules/common.nix
@@ -5,4 +5,6 @@
     pkgs.git
     pkgs.uv
   ];
+
+  home.file.".config/issl/git/.gitconfig".source = ../assets/git/.gitconfig;
 }

--- a/home-modules/git.nix
+++ b/home-modules/git.nix
@@ -1,5 +1,0 @@
-_:
-
-{
-  home.file.".config/issl/git/.gitconfig".source = ../assets/git/.gitconfig;
-}

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -1,6 +1,0 @@
-{ pkgs }:
-
-[
-  pkgs.git
-  pkgs.uv
-]

--- a/profiles/issl-common.nix
+++ b/profiles/issl-common.nix
@@ -1,6 +1,0 @@
-{ pkgs, packageSets }:
-
-pkgs.symlinkJoin {
-  name = "issl-common";
-  paths = packageSets.common;
-}

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -3,12 +3,11 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-profile_name="issl-common"
 shared_git_config_path="${XDG_CONFIG_HOME:-$HOME/.config}/issl/git/.gitconfig"
-nix_profile_path="${NIX_PROFILE_PATH:-}"
 git_user_name="${GIT_USER_NAME:-}"
 git_user_email="${GIT_USER_EMAIL:-}"
 nix_feature_config="experimental-features = nix-command flakes"
+hm_profile_dir="${XDG_STATE_HOME:-$HOME/.local/state}/nix/profiles"
 
 ensure_git_include() {
   if ! git config --global --get-all include.path | grep -Fxq "${shared_git_config_path}"; then
@@ -49,6 +48,10 @@ prompt_for_git_identity() {
   fi
 }
 
+ensure_home_manager_profile_dir() {
+  mkdir -p "${hm_profile_dir}"
+}
+
 if ! command -v nix >/dev/null 2>&1; then
   echo "nix is required before running scripts/apply.sh." >&2
   exit 1
@@ -66,16 +69,7 @@ current_system="$(
 )"
 home_configuration_name="issl-common-${current_system}"
 
-if [ -n "${nix_profile_path}" ]; then
-  nix profile add "${repo_root}#${profile_name}" \
-    --accept-flake-config \
-    --extra-experimental-features "nix-command flakes" \
-    --profile "${nix_profile_path}"
-else
-  nix profile add "${repo_root}#${profile_name}" \
-    --accept-flake-config \
-    --extra-experimental-features "nix-command flakes"
-fi
+ensure_home_manager_profile_dir
 
 nix --accept-flake-config --extra-experimental-features "nix-command flakes" run "${repo_root}#home-manager" -- \
   switch --flake "${repo_root}#${home_configuration_name}" --impure
@@ -83,9 +77,4 @@ nix --accept-flake-config --extra-experimental-features "nix-command flakes" run
 ensure_git_include
 prompt_for_git_identity
 
-echo "Installed the ISSL environment packages and applied shared Home Manager configuration."
-echo "Installed package set: ${profile_name}"
-echo "Shared git config: ${shared_git_config_path}"
-if [ -n "${nix_profile_path}" ]; then
-  echo "Nix profile path: ${nix_profile_path}"
-fi
+echo "Applied the shared Home Manager configuration."

--- a/tests/test-git.sh
+++ b/tests/test-git.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-profile_path="${PROFILE_PATH:?PROFILE_PATH is required}"
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+nix_profile_bin="${home_dir}/.nix-profile/bin"
 
 assert_git_installation() {
-  test -x "${profile_path}/bin/git"
-  PATH="${profile_path}/bin:${PATH}" git --version
+  test -x "${nix_profile_bin}/git"
+  test "$(command -v git)" = "${nix_profile_bin}/git"
+  git --version
 }
 
 assert_shared_git_config() {

--- a/tests/test-uv.sh
+++ b/tests/test-uv.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-profile_path="${PROFILE_PATH:?PROFILE_PATH is required}"
+home_dir="${HOME_DIR:?HOME_DIR is required}"
+nix_profile_bin="${home_dir}/.nix-profile/bin"
 
 assert_uv_installation() {
-  test -x "${profile_path}/bin/uv"
-  PATH="${profile_path}/bin:${PATH}" uv --version
+  test -x "${nix_profile_bin}/uv"
+  test "$(command -v uv)" = "${nix_profile_bin}/uv"
+  uv --version
 }
 
 main() {


### PR DESCRIPTION
## Summary
- move common package installation from `nix profile add` into Home Manager `home.packages`
- remove the old package/profile flake outputs and simplify `apply.sh` to run Home Manager only
- update CI tests to assert commands resolve from `~/.nix-profile/bin`

## Testing
- `prek run --files flake.nix home-modules/common.nix scripts/apply.sh .github/workflows/test.yaml tests/test-git.sh tests/test-uv.sh`
- isolated Docker verification with `nixos/nix:latest` confirming `git` and `uv` land in `~/.nix-profile/bin`