### PR TITLE
feat: add shared shell environment setup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,7 @@ jobs:
             XDG_CONFIG_HOME="${CONFIG_DIR}" \
             XDG_DATA_HOME="${DATA_DIR}" \
             XDG_STATE_HOME="${STATE_DIR}" \
+            ISSL_ENABLE_ZSH="1" \
             GIT_USER_NAME="ISSL Test User" \
             GIT_USER_EMAIL="issl-test@example.com" \
             bash ./scripts/apply.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,6 +82,7 @@ jobs:
       - name: Test shell setup
         shell: bash
         env:
+          PROFILE_PATH: ${{ steps.test-env.outputs.profile_path }}
           HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
           CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
         run: ./tests/test-shell.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,10 +32,18 @@ permissions:
 
 jobs:
   install:
-    name: Test apply.sh
+    name: Test apply.sh (${{ matrix.enable_zsh_name }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - enable_zsh: "0"
+            enable_zsh_name: "zsh disabled"
+          - enable_zsh: "1"
+            enable_zsh_name: "zsh enabled"
 
     steps:
       - name: Checkout the main repository
@@ -74,7 +82,7 @@ jobs:
             XDG_CONFIG_HOME="${CONFIG_DIR}" \
             XDG_DATA_HOME="${DATA_DIR}" \
             XDG_STATE_HOME="${STATE_DIR}" \
-            ISSL_ENABLE_ZSH="1" \
+            ISSL_ENABLE_ZSH="${{ matrix.enable_zsh }}" \
             GIT_USER_NAME="ISSL Test User" \
             GIT_USER_EMAIL="issl-test@example.com" \
             bash ./scripts/apply.sh
@@ -90,6 +98,7 @@ jobs:
         env:
           HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
           CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
+          ISSL_ENABLE_ZSH: ${{ matrix.enable_zsh }}
         run: ./tests/test-shell.sh
 
       - name: Test git setup

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,19 +79,18 @@ jobs:
             GIT_USER_EMAIL="issl-test@example.com" \
             bash ./scripts/apply.sh
 
-      - name: Test shell setup
-        shell: bash
-        env:
-          PROFILE_PATH: ${{ steps.test-env.outputs.profile_path }}
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
-        run: ./tests/test-shell.sh
-
       - name: Add Home Manager profile to PATH
         shell: bash
         env:
           HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
         run: echo "${HOME_DIR}/.nix-profile/bin" >> "${GITHUB_PATH}"
+
+      - name: Test shell setup
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
+        run: ./tests/test-shell.sh
 
       - name: Test git setup
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,6 @@ on:
       - flake.nix
       - flake.lock
       - home-modules/**
-      - packages/**
-      - profiles/**
       - scripts/apply.sh
       - tests/**
   pull_request:
@@ -22,8 +20,6 @@ on:
       - flake.nix
       - flake.lock
       - home-modules/**
-      - packages/**
-      - profiles/**
       - scripts/apply.sh
       - tests/**
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,6 +78,13 @@ jobs:
             GIT_USER_EMAIL="issl-test@example.com" \
             bash ./scripts/apply.sh
 
+      - name: Test shell setup
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
+        run: ./tests/test-shell.sh
+
       - name: Add Home Manager profile to PATH
         shell: bash
         env:

--- a/assets/bash/.bash_profile
+++ b/assets/bash/.bash_profile
@@ -1,0 +1,6 @@
+# shellcheck shell=sh
+# shellcheck disable=SC1091
+
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh"
+fi

--- a/assets/bash/.bashrc
+++ b/assets/bash/.bashrc
@@ -1,0 +1,10 @@
+# shellcheck shell=sh
+# shellcheck disable=SC1091
+
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh"
+fi
+
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh"
+fi

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -1,9 +1,9 @@
 # shellcheck shell=sh
 
-issl_config_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
-export ISSL_CONFIG_HOME="${issl_config_home}"
+export ISSL_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
 
-issl_prepend_path() {
+# Prepend one existing directory to PATH if it is not already present.
+prepend_path() {
   [ "$#" -eq 1 ] || return 0
   [ -d "$1" ] || return 0
 

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -12,3 +12,5 @@ prepend_path() {
   *) PATH="$1${PATH:+:$PATH}" ;;
   esac
 }
+
+prepend_path "$HOME/.local/bin"

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=sh
+
+issl_config_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
+export ISSL_CONFIG_HOME="${issl_config_home}"
+
+issl_prepend_path() {
+  [ "$#" -eq 1 ] || return 0
+  [ -d "$1" ] || return 0
+
+  case ":${PATH}:" in
+  *:"$1":*) ;;
+  *) PATH="$1${PATH:+:$PATH}" ;;
+  esac
+}

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -1,0 +1,1 @@
+# shellcheck shell=sh

--- a/assets/zsh/.zprofile
+++ b/assets/zsh/.zprofile
@@ -1,0 +1,6 @@
+# shellcheck shell=sh
+# shellcheck disable=SC1091
+
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh"
+fi

--- a/assets/zsh/.zshrc
+++ b/assets/zsh/.zshrc
@@ -8,3 +8,16 @@ fi
 if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh" ]; then
   . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh"
 fi
+
+# ===== History ===== #
+
+export HISTFILE="${ZDOTDIR}/.zsh_history"  # Store history under the active ZDOTDIR.
+export HISTSIZE=1000                       # Keep up to 1000 commands in memory.
+export SAVEHIST=10000                      # Persist up to 10000 commands to HISTFILE.
+
+setopt append_history        # Append history entries instead of overwriting the file.
+setopt extended_history      # Record execution timestamps in history entries.
+setopt hist_ignore_all_dups  # Remove older duplicates when a command repeats.
+setopt hist_ignore_space     # Skip commands that start with a space.
+setopt hist_reduce_blanks    # Compress redundant internal whitespace before saving.
+setopt share_history         # Share history across concurrent zsh sessions.

--- a/assets/zsh/.zshrc
+++ b/assets/zsh/.zshrc
@@ -1,0 +1,10 @@
+# shellcheck shell=sh
+# shellcheck disable=SC1091
+
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh"
+fi
+
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh"
+fi

--- a/flake.nix
+++ b/flake.nix
@@ -17,15 +17,15 @@
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
       mkPkgs = system: import nixpkgs { inherit system; };
+      enableZsh =
+        let
+          value = builtins.getEnv "ISSL_ENABLE_ZSH";
+        in
+        value == "1";
       mkHomeConfiguration =
         system:
         let
           pkgs = mkPkgs system;
-          enableZsh =
-            let
-              value = builtins.getEnv "ISSL_ENABLE_ZSH";
-            in
-            value == "1";
           username =
             let
               value = builtins.getEnv "USER";
@@ -39,6 +39,7 @@
         in
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
+          extraSpecialArgs = { inherit enableZsh; };
           modules = [
             ./home-modules/common.nix
             ./home-modules/shell.nix

--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,11 @@
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
       mkPkgs = system: import nixpkgs { inherit system; };
-      enableZsh =
-        let
-          value = builtins.getEnv "ISSL_ENABLE_ZSH";
-        in
-        value == "1";
       mkHomeConfiguration =
-        system:
+        {
+          system,
+          enableZsh ? false,
+        }:
         let
           pkgs = mkPkgs system;
           username =
@@ -39,9 +37,11 @@
         in
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
-          extraSpecialArgs = { inherit enableZsh; };
           modules = [
             ./home-modules/common.nix
+          ]
+          ++ nixpkgs.lib.optional enableZsh ./home-modules/zsh.nix
+          ++ [
             {
               home = {
                 inherit username homeDirectory;
@@ -61,8 +61,20 @@
       );
 
       homeConfigurations = {
-        issl-common-x86_64-linux = mkHomeConfiguration "x86_64-linux";
-        issl-common-aarch64-linux = mkHomeConfiguration "aarch64-linux";
+        issl-common-x86_64-linux = mkHomeConfiguration {
+          system = "x86_64-linux";
+        };
+        issl-common-aarch64-linux = mkHomeConfiguration {
+          system = "aarch64-linux";
+        };
+        issl-common-zsh-x86_64-linux = mkHomeConfiguration {
+          system = "x86_64-linux";
+          enableZsh = true;
+        };
+        issl-common-zsh-aarch64-linux = mkHomeConfiguration {
+          system = "aarch64-linux";
+          enableZsh = true;
+        };
       };
 
       formatter = forAllSystems (system: (mkPkgs system).nixfmt-rfc-style);
@@ -71,6 +83,7 @@
         system:
         {
           home = self.homeConfigurations."issl-common-${system}".activationPackage;
+          home-zsh = self.homeConfigurations."issl-common-zsh-${system}".activationPackage;
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -42,11 +42,6 @@
           extraSpecialArgs = { inherit enableZsh; };
           modules = [
             ./home-modules/common.nix
-            ./home-modules/shell.nix
-            ./home-modules/bash.nix
-          ]
-          ++ nixpkgs.lib.optional enableZsh ./home-modules/zsh.nix
-          ++ [
             {
               home = {
                 inherit username homeDirectory;

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
           modules = [
             ./home-modules/common.nix
             ./home-modules/shell.nix
+            ./home-modules/bash.nix
+            ./home-modules/zsh.nix
             {
               home = {
                 inherit username homeDirectory;

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,11 @@
         system:
         let
           pkgs = mkPkgs system;
+          enableZsh =
+            let
+              value = builtins.getEnv "ISSL_ENABLE_ZSH";
+            in
+            value == "1";
           username =
             let
               value = builtins.getEnv "USER";
@@ -38,7 +43,9 @@
             ./home-modules/common.nix
             ./home-modules/shell.nix
             ./home-modules/bash.nix
-            ./home-modules/zsh.nix
+          ]
+          ++ nixpkgs.lib.optional enableZsh ./home-modules/zsh.nix
+          ++ [
             {
               home = {
                 inherit username homeDirectory;

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
           inherit pkgs;
           modules = [
             ./home-modules/common.nix
+            ./home-modules/shell.nix
             {
               home = {
                 inherit username homeDirectory;

--- a/home-modules/bash.nix
+++ b/home-modules/bash.nix
@@ -1,0 +1,6 @@
+_:
+
+{
+  home.file.".config/issl/bash/.bash_profile".source = ../assets/bash/.bash_profile;
+  home.file.".config/issl/bash/.bashrc".source = ../assets/bash/.bashrc;
+}

--- a/home-modules/bash.nix
+++ b/home-modules/bash.nix
@@ -1,6 +1,0 @@
-_:
-
-{
-  home.file.".config/issl/bash/.bash_profile".source = ../assets/bash/.bash_profile;
-  home.file.".config/issl/bash/.bashrc".source = ../assets/bash/.bashrc;
-}

--- a/home-modules/common.nix
+++ b/home-modules/common.nix
@@ -1,10 +1,9 @@
-{ pkgs, enableZsh ? false, ... }:
+{ lib, enableZsh ? false, ... }:
 
 {
-  home.packages = [
-    pkgs.git
-    pkgs.uv
-  ] ++ pkgs.lib.optional enableZsh pkgs.zsh;
-
-  home.file.".config/issl/git/.gitconfig".source = ../assets/git/.gitconfig;
+  imports = [
+    ./shell.nix
+    ./git.nix
+    ./python.nix
+  ] ++ lib.optional enableZsh ./zsh.nix;
 }

--- a/home-modules/common.nix
+++ b/home-modules/common.nix
@@ -1,9 +1,9 @@
-{ lib, enableZsh ? false, ... }:
+_:
 
 {
   imports = [
     ./shell.nix
     ./git.nix
     ./python.nix
-  ] ++ lib.optional enableZsh ./zsh.nix;
+  ];
 }

--- a/home-modules/common.nix
+++ b/home-modules/common.nix
@@ -1,10 +1,10 @@
-{ pkgs, ... }:
+{ pkgs, enableZsh ? false, ... }:
 
 {
   home.packages = [
     pkgs.git
     pkgs.uv
-  ];
+  ] ++ pkgs.lib.optional enableZsh pkgs.zsh;
 
   home.file.".config/issl/git/.gitconfig".source = ../assets/git/.gitconfig;
 }

--- a/home-modules/git.nix
+++ b/home-modules/git.nix
@@ -1,7 +1,8 @@
 { pkgs, ... }:
 
 {
-  home.packages = [ pkgs.git ];
-
-  home.file.".config/issl/git/.gitconfig".source = ../assets/git/.gitconfig;
+  home = {
+    packages = [ pkgs.git ];
+    file.".config/issl/git/.gitconfig".source = ../assets/git/.gitconfig;
+  };
 }

--- a/home-modules/git.nix
+++ b/home-modules/git.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [ pkgs.git ];
+
+  home.file.".config/issl/git/.gitconfig".source = ../assets/git/.gitconfig;
+}

--- a/home-modules/python.nix
+++ b/home-modules/python.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [ pkgs.uv ];
+}

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -2,9 +2,11 @@ _:
 
 {
   home = {
-    file.".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
-    file.".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;
-    file.".config/issl/bash/.bash_profile".source = ../assets/bash/.bash_profile;
-    file.".config/issl/bash/.bashrc".source = ../assets/bash/.bashrc;
+    file = {
+      ".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
+      ".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;
+      ".config/issl/bash/.bash_profile".source = ../assets/bash/.bash_profile;
+      ".config/issl/bash/.bashrc".source = ../assets/bash/.bashrc;
+    };
   };
 }

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -1,0 +1,5 @@
+_:
+
+{
+  home.file.".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
+}

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -3,4 +3,6 @@ _:
 {
   home.file.".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
   home.file.".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;
+  home.file.".config/issl/bash/.bash_profile".source = ../assets/bash/.bash_profile;
+  home.file.".config/issl/bash/.bashrc".source = ../assets/bash/.bashrc;
 }

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -2,4 +2,5 @@ _:
 
 {
   home.file.".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
+  home.file.".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;
 }

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -1,8 +1,10 @@
 _:
 
 {
-  home.file.".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
-  home.file.".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;
-  home.file.".config/issl/bash/.bash_profile".source = ../assets/bash/.bash_profile;
-  home.file.".config/issl/bash/.bashrc".source = ../assets/bash/.bashrc;
+  home = {
+    file.".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
+    file.".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;
+    file.".config/issl/bash/.bash_profile".source = ../assets/bash/.bash_profile;
+    file.".config/issl/bash/.bashrc".source = ../assets/bash/.bashrc;
+  };
 }

--- a/home-modules/zsh.nix
+++ b/home-modules/zsh.nix
@@ -3,7 +3,9 @@
 {
   home = {
     packages = [ pkgs.zsh ];
-    file.".config/issl/zsh/.zprofile".source = ../assets/zsh/.zprofile;
-    file.".config/issl/zsh/.zshrc".source = ../assets/zsh/.zshrc;
+    file = {
+      ".config/issl/zsh/.zprofile".source = ../assets/zsh/.zprofile;
+      ".config/issl/zsh/.zshrc".source = ../assets/zsh/.zshrc;
+    };
   };
 }

--- a/home-modules/zsh.nix
+++ b/home-modules/zsh.nix
@@ -1,0 +1,6 @@
+_:
+
+{
+  home.file.".config/issl/zsh/.zprofile".source = ../assets/zsh/.zprofile;
+  home.file.".config/issl/zsh/.zshrc".source = ../assets/zsh/.zshrc;
+}

--- a/home-modules/zsh.nix
+++ b/home-modules/zsh.nix
@@ -1,6 +1,8 @@
-_:
+{ pkgs, ... }:
 
 {
+  home.packages = [ pkgs.zsh ];
+
   home.file.".config/issl/zsh/.zprofile".source = ../assets/zsh/.zprofile;
   home.file.".config/issl/zsh/.zshrc".source = ../assets/zsh/.zshrc;
 }

--- a/home-modules/zsh.nix
+++ b/home-modules/zsh.nix
@@ -1,8 +1,9 @@
 { pkgs, ... }:
 
 {
-  home.packages = [ pkgs.zsh ];
-
-  home.file.".config/issl/zsh/.zprofile".source = ../assets/zsh/.zprofile;
-  home.file.".config/issl/zsh/.zshrc".source = ../assets/zsh/.zshrc;
+  home = {
+    packages = [ pkgs.zsh ];
+    file.".config/issl/zsh/.zprofile".source = ../assets/zsh/.zprofile;
+    file.".config/issl/zsh/.zshrc".source = ../assets/zsh/.zshrc;
+  };
 }

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -86,11 +86,11 @@ EOF
 }
 
 resolve_zdotdir_from_zshenv() {
-  # shellcheck disable=SC2016
   local zshenv_path="$1"
   local raw_value=""
 
   raw_value="$(
+    # shellcheck disable=SC2016
     sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?ZDOTDIR[[:space:]]*=[[:space:]]*//p' "${zshenv_path}" |
       tail -n 1
   )"
@@ -105,8 +105,8 @@ resolve_zdotdir_from_zshenv() {
 
   # shellcheck disable=SC2016
   case "${raw_value}" in
-  '$HOME'/*) printf '%s\n' "${HOME}/${raw_value#\$HOME/}" ;;
-  '${HOME}'/*) printf '%s\n' "${HOME}/${raw_value#\$\{HOME\}/}" ;;
+  \$HOME/*) printf '%s\n' "${HOME}/${raw_value#\$HOME/}" ;;
+  \$\{HOME\}/*) printf '%s\n' "${HOME}/${raw_value#\$\{HOME\}/}" ;;
   ~/*) printf '%s\n' "${HOME}/${raw_value#~/}" ;;
   /*) printf '%s\n' "${raw_value}" ;;
   *) return 1 ;;

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -3,7 +3,12 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-shared_git_config_path="${XDG_CONFIG_HOME:-$HOME/.config}/issl/git/.gitconfig"
+issl_config_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
+shared_git_config_path="${issl_config_home}/git/.gitconfig"
+shared_bash_profile_path="${issl_config_home}/bash/.bash_profile"
+shared_bashrc_path="${issl_config_home}/bash/.bashrc"
+shared_zprofile_path="${issl_config_home}/zsh/.zprofile"
+shared_zshrc_path="${issl_config_home}/zsh/.zshrc"
 git_user_name="${GIT_USER_NAME:-}"
 git_user_email="${GIT_USER_EMAIL:-}"
 issl_enable_zsh="${ISSL_ENABLE_ZSH:-}"
@@ -46,19 +51,17 @@ prepend_block_once() {
 }
 
 bash_profile_block() {
-  cat <<'EOF'
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/bash/.bash_profile" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/bash/.bash_profile"
-fi
-EOF
+  printf '%s\n' \
+    "if [ -f \"${shared_bash_profile_path}\" ]; then" \
+    "  . \"${shared_bash_profile_path}\"" \
+    "fi"
 }
 
 bashrc_block() {
-  cat <<'EOF'
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/bash/.bashrc" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/bash/.bashrc"
-fi
-EOF
+  printf '%s\n' \
+    "if [ -f \"${shared_bashrc_path}\" ]; then" \
+    "  . \"${shared_bashrc_path}\"" \
+    "fi"
 }
 
 zshenv_default_block() {
@@ -70,19 +73,17 @@ EOF
 }
 
 zprofile_block() {
-  cat <<'EOF'
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/zsh/.zprofile" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/zsh/.zprofile"
-fi
-EOF
+  printf '%s\n' \
+    "if [ -f \"${shared_zprofile_path}\" ]; then" \
+    "  . \"${shared_zprofile_path}\"" \
+    "fi"
 }
 
 zshrc_block() {
-  cat <<'EOF'
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/zsh/.zshrc" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/zsh/.zshrc"
-fi
-EOF
+  printf '%s\n' \
+    "if [ -f \"${shared_zshrc_path}\" ]; then" \
+    "  . \"${shared_zshrc_path}\"" \
+    "fi"
 }
 
 resolve_zdotdir_from_zshenv() {

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -252,20 +252,21 @@ current_system="$(
   nix --accept-flake-config --extra-experimental-features "nix-command flakes" \
     eval --impure --raw --expr builtins.currentSystem
 )"
-home_configuration_name="issl-common-${current_system}"
 
 ensure_home_manager_profile_dir
 if should_enable_zsh; then
-  export ISSL_ENABLE_ZSH=1
+  home_configuration_name="issl-common-zsh-${current_system}"
+  zsh_enabled=1
 else
-  export ISSL_ENABLE_ZSH=0
+  home_configuration_name="issl-common-${current_system}"
+  zsh_enabled=0
 fi
 
 nix --accept-flake-config --extra-experimental-features "nix-command flakes" run "${repo_root}#home-manager" -- \
   switch --flake "${repo_root}#${home_configuration_name}" --impure
 
 ensure_bash_startup_files
-if [ "${ISSL_ENABLE_ZSH}" = "1" ]; then
+if [ "${zsh_enabled}" = "1" ]; then
   ensure_zsh_startup_files
 fi
 ensure_git_include

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -6,6 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 shared_git_config_path="${XDG_CONFIG_HOME:-$HOME/.config}/issl/git/.gitconfig"
 git_user_name="${GIT_USER_NAME:-}"
 git_user_email="${GIT_USER_EMAIL:-}"
+issl_enable_zsh="${ISSL_ENABLE_ZSH:-}"
 nix_feature_config="experimental-features = nix-command flakes"
 hm_profile_dir="${XDG_STATE_HOME:-$HOME/.local/state}/nix/profiles"
 
@@ -52,6 +53,48 @@ ensure_home_manager_profile_dir() {
   mkdir -p "${hm_profile_dir}"
 }
 
+is_yes() {
+  case "${1:-}" in
+  y | Y | yes | YES | Yes | true | TRUE | True | 1) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+is_no() {
+  case "${1:-}" in
+  n | N | no | NO | No | false | FALSE | False | 0) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+should_enable_zsh() {
+  local current_shell_name=""
+  local response=""
+
+  if [ -n "${issl_enable_zsh}" ]; then
+    if is_yes "${issl_enable_zsh}"; then
+      return 0
+    fi
+    if is_no "${issl_enable_zsh}"; then
+      return 1
+    fi
+    echo "ISSL_ENABLE_ZSH must be a yes/no style value." >&2
+    exit 1
+  fi
+
+  current_shell_name="$(basename "${SHELL:-}")"
+  if [ "${current_shell_name}" = "zsh" ]; then
+    return 0
+  fi
+
+  if [ ! -t 0 ]; then
+    return 1
+  fi
+
+  read -r -p "Enable shared zsh configuration as well? [y/N] " response
+  is_yes "${response}"
+}
+
 if ! command -v nix >/dev/null 2>&1; then
   echo "nix is required before running scripts/apply.sh." >&2
   exit 1
@@ -69,6 +112,12 @@ current_system="$(
 )"
 home_configuration_name="issl-common-${current_system}"
 
+ensure_home_manager_profile_dir
+if should_enable_zsh; then
+  export ISSL_ENABLE_ZSH=1
+else
+  export ISSL_ENABLE_ZSH=0
+fi
 ensure_home_manager_profile_dir
 
 nix --accept-flake-config --extra-experimental-features "nix-command flakes" run "${repo_root}#home-manager" -- \

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -118,7 +118,6 @@ if should_enable_zsh; then
 else
   export ISSL_ENABLE_ZSH=0
 fi
-ensure_home_manager_profile_dir
 
 nix --accept-flake-config --extra-experimental-features "nix-command flakes" run "${repo_root}#home-manager" -- \
   switch --flake "${repo_root}#${home_configuration_name}" --impure

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -16,6 +16,147 @@ ensure_git_include() {
   fi
 }
 
+prepend_block_once() {
+  local file_path="$1"
+  local begin_marker="$2"
+  local end_marker="$3"
+  local block_content="$4"
+  local file_dir=""
+  local temp_file=""
+
+  file_dir="$(dirname "${file_path}")"
+  mkdir -p "${file_dir}"
+  touch "${file_path}"
+
+  if grep -Fq "${begin_marker}" "${file_path}"; then
+    return
+  fi
+
+  temp_file="$(mktemp)"
+  {
+    printf '%s\n' "${begin_marker}"
+    printf '%s\n' "${block_content}"
+    printf '%s\n' "${end_marker}"
+    if [ -s "${file_path}" ]; then
+      printf '\n'
+      cat "${file_path}"
+    fi
+  } >"${temp_file}"
+  mv "${temp_file}" "${file_path}"
+}
+
+bash_profile_block() {
+  cat <<'EOF'
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/bash/.bash_profile" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/bash/.bash_profile"
+fi
+EOF
+}
+
+bashrc_block() {
+  cat <<'EOF'
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/bash/.bashrc" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/bash/.bashrc"
+fi
+EOF
+}
+
+zshenv_default_block() {
+  cat <<'EOF'
+if [ -z "${ZDOTDIR:-}" ]; then
+  export ZDOTDIR="$HOME/.zsh"
+fi
+EOF
+}
+
+zprofile_block() {
+  cat <<'EOF'
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/zsh/.zprofile" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/zsh/.zprofile"
+fi
+EOF
+}
+
+zshrc_block() {
+  cat <<'EOF'
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/zsh/.zshrc" ]; then
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/zsh/.zshrc"
+fi
+EOF
+}
+
+resolve_zdotdir_from_zshenv() {
+  # shellcheck disable=SC2016
+  local zshenv_path="$1"
+  local raw_value=""
+
+  raw_value="$(
+    sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?ZDOTDIR[[:space:]]*=[[:space:]]*//p' "${zshenv_path}" |
+      tail -n 1
+  )"
+  [ -n "${raw_value}" ] || return 1
+
+  case "${raw_value}" in
+  \"*\" | \'*\')
+    raw_value="${raw_value#?}"
+    raw_value="${raw_value%?}"
+    ;;
+  esac
+
+  # shellcheck disable=SC2016
+  case "${raw_value}" in
+  '$HOME'/*) printf '%s\n' "${HOME}/${raw_value#\$HOME/}" ;;
+  '${HOME}'/*) printf '%s\n' "${HOME}/${raw_value#\$\{HOME\}/}" ;;
+  ~/*) printf '%s\n' "${HOME}/${raw_value#~/}" ;;
+  /*) printf '%s\n' "${raw_value}" ;;
+  *) return 1 ;;
+  esac
+}
+
+ensure_bash_startup_files() {
+  prepend_block_once \
+    "${HOME}/.bash_profile" \
+    "# >>> ISSL bash profile >>>" \
+    "# <<< ISSL bash profile <<<" \
+    "$(bash_profile_block)"
+  prepend_block_once \
+    "${HOME}/.bashrc" \
+    "# >>> ISSL bash rc >>>" \
+    "# <<< ISSL bash rc <<<" \
+    "$(bashrc_block)"
+}
+
+ensure_zsh_startup_files() {
+  local zshenv_path="${HOME}/.zshenv"
+  local zdotdir_path=""
+
+  if [ -f "${zshenv_path}" ] && grep -Eq '^[[:space:]]*(export[[:space:]]+)?ZDOTDIR[[:space:]]*=' "${zshenv_path}"; then
+    if ! zdotdir_path="$(resolve_zdotdir_from_zshenv "${zshenv_path}")"; then
+      echo "Could not determine ZDOTDIR from ${zshenv_path}." >&2
+      exit 1
+    fi
+  else
+    prepend_block_once \
+      "${zshenv_path}" \
+      "# >>> ISSL zsh env >>>" \
+      "# <<< ISSL zsh env <<<" \
+      "$(zshenv_default_block)"
+    zdotdir_path="${HOME}/.zsh"
+  fi
+
+  mkdir -p "${zdotdir_path}"
+  prepend_block_once \
+    "${zdotdir_path}/.zprofile" \
+    "# >>> ISSL zsh profile >>>" \
+    "# <<< ISSL zsh profile <<<" \
+    "$(zprofile_block)"
+  prepend_block_once \
+    "${zdotdir_path}/.zshrc" \
+    "# >>> ISSL zsh rc >>>" \
+    "# <<< ISSL zsh rc <<<" \
+    "$(zshrc_block)"
+}
+
 prompt_for_git_identity() {
   local git_name=""
   local git_email=""
@@ -122,6 +263,10 @@ fi
 nix --accept-flake-config --extra-experimental-features "nix-command flakes" run "${repo_root}#home-manager" -- \
   switch --flake "${repo_root}#${home_configuration_name}" --impure
 
+ensure_bash_startup_files
+if [ "${ISSL_ENABLE_ZSH}" = "1" ]; then
+  ensure_zsh_startup_files
+fi
 ensure_git_include
 prompt_for_git_identity
 

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -88,30 +88,32 @@ zshrc_block() {
 
 resolve_zdotdir_from_zshenv() {
   local zshenv_path="$1"
-  local raw_value=""
+  local zsh_bin=""
+  local resolved_value=""
 
-  raw_value="$(
+  if [ -x "${HOME}/.nix-profile/bin/zsh" ]; then
+    zsh_bin="${HOME}/.nix-profile/bin/zsh"
+  elif command -v zsh >/dev/null 2>&1; then
+    zsh_bin="$(command -v zsh)"
+  else
+    return 1
+  fi
+
+  resolved_value="$(
+    env -i \
+      HOME="${HOME}" \
+      XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}" \
+      ZDOTDIR=""
     # shellcheck disable=SC2016
-    sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?ZDOTDIR[[:space:]]*=[[:space:]]*//p' "${zshenv_path}" |
-      tail -n 1
+    "${zsh_bin}" -c '
+        . "$1"
+        if [ -n "${ZDOTDIR:-}" ]; then
+          print -r -- "${ZDOTDIR:A}"
+        fi
+      ' _ "${zshenv_path}"
   )"
-  [ -n "${raw_value}" ] || return 1
-
-  case "${raw_value}" in
-  \"*\" | \'*\')
-    raw_value="${raw_value#?}"
-    raw_value="${raw_value%?}"
-    ;;
-  esac
-
-  # shellcheck disable=SC2016
-  case "${raw_value}" in
-  \$HOME/*) printf '%s\n' "${HOME}/${raw_value#\$HOME/}" ;;
-  \$\{HOME\}/*) printf '%s\n' "${HOME}/${raw_value#\$\{HOME\}/}" ;;
-  ~/*) printf '%s\n' "${HOME}/${raw_value#~/}" ;;
-  /*) printf '%s\n' "${raw_value}" ;;
-  *) return 1 ;;
-  esac
+  [ -n "${resolved_value}" ] || return 1
+  printf '%s\n' "${resolved_value}"
 }
 
 ensure_bash_startup_files() {

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+nix_profile_bin="${home_dir}/.nix-profile/bin"
 default_zdotdir="${home_dir}/.zsh"
 
 assert_shared_shell_env() {
@@ -29,6 +30,10 @@ assert_bash_startup_files() {
   grep -Fq "${config_dir}/issl/bash/.bashrc" "${home_dir}/.bashrc"
 }
 
+assert_zsh_installation() {
+  test -x "${nix_profile_bin}/zsh"
+}
+
 assert_default_zsh_startup_files() {
   grep -Fq '# >>> ISSL zsh env >>>' "${home_dir}/.zshenv"
   # shellcheck disable=SC2016
@@ -43,6 +48,7 @@ main() {
   assert_shared_shell_env
   assert_shell_env_can_be_sourced
   assert_bash_startup_files
+  assert_zsh_installation
   assert_default_zsh_startup_files
 }
 

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -5,6 +5,7 @@ home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 default_zdotdir="${home_dir}/.zsh"
+issl_enable_zsh="${ISSL_ENABLE_ZSH:?ISSL_ENABLE_ZSH is required}"
 
 assert_shared_shell_env() {
   cmp --silent assets/shell/env.sh "${config_dir}/issl/shell/env.sh"
@@ -30,11 +31,11 @@ assert_bash_startup_files() {
   grep -Fq "${config_dir}/issl/bash/.bashrc" "${home_dir}/.bashrc"
 }
 
-assert_zsh_installation() {
+assert_zsh_enabled() {
   test -x "${nix_profile_bin}/zsh"
 }
 
-assert_default_zsh_startup_files() {
+assert_default_zsh_startup_files_enabled() {
   grep -Fq '# >>> ISSL zsh env >>>' "${home_dir}/.zshenv"
   # shellcheck disable=SC2016
   grep -Fq 'export ZDOTDIR="$HOME/.zsh"' "${home_dir}/.zshenv"
@@ -44,12 +45,24 @@ assert_default_zsh_startup_files() {
   grep -Fq "${config_dir}/issl/zsh/.zshrc" "${default_zdotdir}/.zshrc"
 }
 
+assert_zsh_disabled() {
+  test ! -x "${nix_profile_bin}/zsh"
+  test ! -e "${home_dir}/.zshenv"
+  test ! -e "${default_zdotdir}/.zprofile"
+  test ! -e "${default_zdotdir}/.zshrc"
+}
+
 main() {
   assert_shared_shell_env
   assert_shell_env_can_be_sourced
   assert_bash_startup_files
-  assert_zsh_installation
-  assert_default_zsh_startup_files
+
+  if [ "${issl_enable_zsh}" = "1" ]; then
+    assert_zsh_enabled
+    assert_default_zsh_startup_files_enabled
+  else
+    assert_zsh_disabled
+  fi
 }
 
 main "$@"

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -11,16 +11,15 @@ assert_shared_shell_env() {
 }
 
 assert_shell_env_can_be_sourced() {
-  # shellcheck disable=SC2016
   env -i \
     HOME="${home_dir}" \
+    SHELL_ENV_PATH="${config_dir}/issl/shell/env.sh" \
     XDG_CONFIG_HOME="${config_dir}" \
     PATH="/usr/bin:/bin" \
-    bash -c '
-      shell_env_path="$1"
-      . "${shell_env_path}"
-      test "${ISSL_CONFIG_HOME}" = "${XDG_CONFIG_HOME}/issl"
-    ' _ "${config_dir}/issl/shell/env.sh"
+    bash <<'EOF'
+. "${SHELL_ENV_PATH}"
+test "${ISSL_CONFIG_HOME}" = "${XDG_CONFIG_HOME}/issl"
+EOF
 }
 
 assert_bash_startup_files() {

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -6,6 +6,7 @@ config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 
 assert_shared_shell_env() {
   cmp --silent assets/shell/env.sh "${config_dir}/issl/shell/env.sh"
+  cmp --silent assets/shell/rc.sh "${config_dir}/issl/shell/rc.sh"
 }
 
 assert_shell_env_can_be_sourced() {

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -19,7 +19,6 @@ assert_shell_env_can_be_sourced() {
       shell_env_path="$1"
       . "${shell_env_path}"
       test "${ISSL_CONFIG_HOME}" = "${XDG_CONFIG_HOME}/issl"
-      prepend_path /does/not/exist
     ' _ "${config_dir}/issl/shell/env.sh"
 }
 

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+home_dir="${HOME_DIR:?HOME_DIR is required}"
+config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+
+assert_shared_shell_env() {
+  cmp --silent assets/shell/env.sh "${config_dir}/issl/shell/env.sh"
+}
+
+assert_shell_env_can_be_sourced() {
+  # shellcheck disable=SC2016
+  env -i \
+    HOME="${home_dir}" \
+    XDG_CONFIG_HOME="${config_dir}" \
+    PATH="/usr/bin:/bin" \
+    bash -c '
+      shell_env_path="$1"
+      . "${shell_env_path}"
+      test "${ISSL_CONFIG_HOME}" = "${XDG_CONFIG_HOME}/issl"
+      issl_prepend_path /does/not/exist
+    ' _ "${config_dir}/issl/shell/env.sh"
+}
+
+main() {
+  assert_shared_shell_env
+  assert_shell_env_can_be_sourced
+}
+
+main "$@"

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -18,7 +18,7 @@ assert_shell_env_can_be_sourced() {
       shell_env_path="$1"
       . "${shell_env_path}"
       test "${ISSL_CONFIG_HOME}" = "${XDG_CONFIG_HOME}/issl"
-      issl_prepend_path /does/not/exist
+      prepend_path /does/not/exist
     ' _ "${config_dir}/issl/shell/env.sh"
 }
 

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+default_zdotdir="${home_dir}/.zsh"
 
 assert_shared_shell_env() {
   cmp --silent assets/shell/env.sh "${config_dir}/issl/shell/env.sh"
@@ -22,9 +23,28 @@ assert_shell_env_can_be_sourced() {
     ' _ "${config_dir}/issl/shell/env.sh"
 }
 
+assert_bash_startup_files() {
+  grep -Fq '# >>> ISSL bash profile >>>' "${home_dir}/.bash_profile"
+  grep -Fq "${config_dir}/issl/bash/.bash_profile" "${home_dir}/.bash_profile"
+  grep -Fq '# >>> ISSL bash rc >>>' "${home_dir}/.bashrc"
+  grep -Fq "${config_dir}/issl/bash/.bashrc" "${home_dir}/.bashrc"
+}
+
+assert_default_zsh_startup_files() {
+  grep -Fq '# >>> ISSL zsh env >>>' "${home_dir}/.zshenv"
+  # shellcheck disable=SC2016
+  grep -Fq 'export ZDOTDIR="$HOME/.zsh"' "${home_dir}/.zshenv"
+  grep -Fq '# >>> ISSL zsh profile >>>' "${default_zdotdir}/.zprofile"
+  grep -Fq "${config_dir}/issl/zsh/.zprofile" "${default_zdotdir}/.zprofile"
+  grep -Fq '# >>> ISSL zsh rc >>>' "${default_zdotdir}/.zshrc"
+  grep -Fq "${config_dir}/issl/zsh/.zshrc" "${default_zdotdir}/.zshrc"
+}
+
 main() {
   assert_shared_shell_env
   assert_shell_env_can_be_sourced
+  assert_bash_startup_files
+  assert_default_zsh_startup_files
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- add shared shell env/rc assets and wire them into user startup files
- add optional zsh support with explicit Home Manager targets and CI coverage for both opt-in paths
- reorganize Home Manager modules and clean up workflow path filters

## Testing
- prek run --files flake.nix scripts/apply.sh home-modules/common.nix .github/workflows/test.yaml tests/test-shell.sh tests/test-git.sh tests/test-uv.sh home-modules/shell.nix home-modules/git.nix home-modules/python.nix home-modules/zsh.nix
- Docker-isolated manual verification for zsh disabled/enabled startup wiring cases