### PR TITLE
feat(shell): add shared shell defaults and tooling

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,5 @@
 [default.extend-words]
+ue = "ue"
 
 [files]
 extend-exclude = []

--- a/assets/bash/.bash_profile
+++ b/assets/bash/.bash_profile
@@ -1,6 +1,8 @@
 # shellcheck shell=sh
 # shellcheck disable=SC1091
 
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh"
+issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
+
+if [ -f "${issl_bootstrap_shell_home}/env.sh" ]; then
+  . "${issl_bootstrap_shell_home}/env.sh"
 fi

--- a/assets/bash/.bash_profile
+++ b/assets/bash/.bash_profile
@@ -1,8 +1,8 @@
-# shellcheck shell=sh
+# shellcheck shell=bash
 # shellcheck disable=SC1091
 
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 
-if [ -f "${issl_bootstrap_shell_home}/env.sh" ]; then
-  . "${issl_bootstrap_shell_home}/env.sh"
+if [[ -f "${issl_bootstrap_shell_home}/env.sh" ]]; then
+  source "${issl_bootstrap_shell_home}/env.sh"
 fi

--- a/assets/bash/.bashrc
+++ b/assets/bash/.bashrc
@@ -1,17 +1,15 @@
 # shellcheck shell=sh
 # shellcheck disable=SC1091
 
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh"
-fi
+issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh"
+if [ -f "${issl_bootstrap_shell_home}/rc.sh" ]; then
+  . "${issl_bootstrap_shell_home}/rc.sh"
 fi
 
 # Enable bash completion from Home Manager profile when available.
-if [ -f "${HOME}/.nix-profile/share/bash-completion/bash_completion" ]; then
-  . "${HOME}/.nix-profile/share/bash-completion/bash_completion"
+if [ -f "${ISSL_NIX_PROFILE_PATH}/share/bash-completion/bash_completion" ]; then
+  . "${ISSL_NIX_PROFILE_PATH}/share/bash-completion/bash_completion"
 elif [ -f "/etc/bash_completion" ]; then
   . "/etc/bash_completion"
 fi

--- a/assets/bash/.bashrc
+++ b/assets/bash/.bashrc
@@ -8,3 +8,10 @@ fi
 if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh" ]; then
   . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh"
 fi
+
+# Enable bash completion from Home Manager profile when available.
+if [ -f "${HOME}/.nix-profile/share/bash-completion/bash_completion" ]; then
+  . "${HOME}/.nix-profile/share/bash-completion/bash_completion"
+elif [ -f "/etc/bash_completion" ]; then
+  . "/etc/bash_completion"
+fi

--- a/assets/bash/.bashrc
+++ b/assets/bash/.bashrc
@@ -1,15 +1,15 @@
-# shellcheck shell=sh
+# shellcheck shell=bash
 # shellcheck disable=SC1091
 
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 
-if [ -f "${issl_bootstrap_shell_home}/rc.sh" ]; then
-  . "${issl_bootstrap_shell_home}/rc.sh"
+if [[ -f "${issl_bootstrap_shell_home}/rc.sh" ]]; then
+  source "${issl_bootstrap_shell_home}/rc.sh"
 fi
 
 # Enable bash completion from Home Manager profile when available.
-if [ -f "${ISSL_NIX_PROFILE_PATH}/share/bash-completion/bash_completion" ]; then
-  . "${ISSL_NIX_PROFILE_PATH}/share/bash-completion/bash_completion"
-elif [ -f "/etc/bash_completion" ]; then
-  . "/etc/bash_completion"
+if [[ -f "${ISSL_NIX_PROFILE_PATH}/share/bash-completion/bash_completion" ]]; then
+  source "${ISSL_NIX_PROFILE_PATH}/share/bash-completion/bash_completion"
+elif [[ -f "/etc/bash_completion" ]]; then
+  source "/etc/bash_completion"
 fi

--- a/assets/shell/.dircolors
+++ b/assets/shell/.dircolors
@@ -1,0 +1,193 @@
+# Configuration file for dircolors, a utility to help you set the
+# LS_COLORS environment variable used by GNU ls with the --color option.
+# Copyright (C) 1996-2018 Free Software Foundation, Inc.
+# Copying and distribution of this file, with or without modification,
+# are permitted provided the copyright notice and this notice are preserved.
+# The keywords COLOR, OPTIONS, and EIGHTBIT (honored by the
+# slackware version of dircolors) are recognized but ignored.
+# Below are TERM entries, which can be a glob patterns, to match
+# against the TERM environment variable to determine if it is colorizable.
+TERM Eterm
+TERM ansi
+TERM *color*
+TERM con[0-9]*x[0-9]*
+TERM cons25
+TERM console
+TERM cygwin
+TERM dtterm
+TERM gnome
+TERM hurd
+TERM jfbterm
+TERM konsole
+TERM kterm
+TERM linux
+TERM linux-c
+TERM mlterm
+TERM putty
+TERM rxvt*
+TERM screen*
+TERM st
+TERM terminator
+TERM tmux*
+TERM vt100
+TERM xterm*
+# Below are the color init strings for the basic file types. A color init
+# string consists of one or more of the following numeric codes:
+# Attribute codes:
+# 00=none 01=bold 04=underscore 05=blink 07=reverse 08=concealed
+# Text color codes:
+# 30=black 31=red 32=green 33=yellow 34=blue 35=magenta 36=cyan 37=white
+# Background color codes:
+# 40=black 41=red 42=green 43=yellow 44=blue 45=magenta 46=cyan 47=white
+#NORMAL 00 # no color code at all
+#FILE 00 # regular file: use no color at all
+RESET 0 # reset to "normal" color
+DIR 01;36 # directory
+LINK 01;35 # symbolic link. (If you set this to 'target' instead of a
+ # numerical value, the color is as for the file pointed to.)
+MULTIHARDLINK 00 # regular file with more than one link
+FIFO 40;33 # pipe
+SOCK 01;35 # socket
+DOOR 01;35 # door
+BLK 40;33;01 # block device driver
+CHR 40;33;01 # character device driver
+ORPHAN 40;31;01 # symlink to nonexistent file, or non-stat'able file ...
+MISSING 00 # ... and the files they point to
+SETUID 37;41 # file that is setuid (u+s)
+SETGID 30;43 # file that is setgid (g+s)
+CAPABILITY 30;41 # file with capability
+STICKY_OTHER_WRITABLE 30;42 # dir that is sticky and other-writable (+t,o+w)
+OTHER_WRITABLE 34;42 # dir that is other-writable (o+w) and not sticky
+STICKY 37;44 # dir with the sticky bit set (+t) and not other-writable
+# This is for files with execute permission:
+EXEC 00;31
+# List any file extensions like '.gz' or '.tar' that you would like ls
+# to colorize below. Put the extension, a space, and the color init string.
+# (and any comments you want to add after a '#')
+# If you use DOS-style suffixes, you may want to uncomment the following:
+.cmd 00;31 # executables (red)
+.exe 00;31
+.com 00;31
+.btm 00;31
+.bat 00;31
+# Or if you want to colorize scripts even if they do not have the executable bit actually set.
+.sh 00;31
+.bash 00;31
+.csh 00;31
+.zsh 00;31
+ # archives or compressed (magenta)
+.tar 00;35
+.tgz 00;35
+.arc 00;35
+.arj 00;35
+.taz 00;35
+.lha 00;35
+.lz4 00;35
+.lzh 00;35
+.lzma 00;35
+.tlz 00;35
+.txz 00;35
+.tzo 00;35
+.t7z 00;35
+.zip 00;35
+.z 00;35
+.dz 00;35
+.gz 00;35
+.lrz 00;35
+.lz 00;35
+.lzo 00;35
+.xz 00;35
+.zst 00;35
+.tzst 00;35
+.bz2 00;35
+.bz 00;35
+.tbz 00;35
+.tbz2 00;35
+.tz 00;35
+.deb 00;35
+.rpm 00;35
+.jar 00;35
+.war 00;35
+.ear 00;35
+.sar 00;35
+.rar 00;35
+.alz 00;35
+.ace 00;35
+.zoo 00;35
+.cpio 00;35
+.7z 00;35
+.rz 00;35
+.cab 00;35
+.wim 00;35
+.swm 00;35
+.dwm 00;35
+.esd 00;35
+# image formats (yellow)
+.jpg 00;33
+.jpeg 00;33
+.mjpg 00;33
+.mjpeg 00;33
+.gif 00;33
+.bmp 00;33
+.pbm 00;33
+.pgm 00;33
+.ppm 00;33
+.tga 00;33
+.xbm 00;33
+.xpm 00;33
+.tif 00;33
+.tiff 00;33
+.png 00;33
+.svg 00;33
+.svgz 00;33
+.mng 00;33
+.pcx 00;33
+.mov 00;33
+.mpg 00;33
+.mpeg 00;33
+.m2v 00;33
+.mkv 00;33
+.webm 00;33
+.ogm 00;33
+.mp4 00;33
+.m4v 00;33
+.mp4v 00;33
+.vob 00;33
+.qt 00;33
+.nuv 00;33
+.wmv 00;33
+.asf 00;33
+.rm 00;33
+.rmvb 00;33
+.flc 00;33
+.avi 00;33
+.fli 00;33
+.flv 00;33
+.gl 00;33
+.dl 00;33
+.xcf 00;33
+.xwd 00;33
+.yuv 00;33
+.cgm 00;33
+.emf 00;33
+# https://wiki.xiph.org/MIME_Types_and_File_Extensions
+.ogv 01;35
+.ogx 01;35
+# audio formats
+.aac 00;36
+.au 00;36
+.flac 00;36
+.m4a 00;36
+.mid 00;36
+.midi 00;36
+.mka 00;36
+.mp3 00;36
+.mpc 00;36
+.ogg 00;36
+.ra 00;36
+.wav 00;36
+# https://wiki.xiph.org/MIME_Types_and_File_Extensions
+.oga 00;36
+.opus 00;36
+.spx 00;36
+.xspf 00;36

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -1,6 +1,8 @@
 # shellcheck shell=sh
 
 export ISSL_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
+export ISSL_SHELL_HOME="${ISSL_CONFIG_HOME}/shell"
+export ISSL_NIX_PROFILE_PATH="${ISSL_NIX_PROFILE_PATH:-$HOME/.nix-profile}"
 
 # Prepend one existing directory to PATH if it is not already present.
 prepend_path() {

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -1,11 +1,18 @@
 # shellcheck shell=sh
+# shellcheck disable=SC1091
+
+issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
+
+if [ -f "${issl_bootstrap_shell_home}/env.sh" ]; then
+  . "${issl_bootstrap_shell_home}/env.sh"
+fi
 
 # ===== Aliases ===== #
 
 # Configure GNU-style color output for common tools when available.
 if command -v dircolors >/dev/null 2>&1; then
   # Prefer ~/.dircolors, then the shared ISSL file.
-  issl_dircolors_path="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/.dircolors"
+  issl_dircolors_path="${ISSL_SHELL_HOME}/.dircolors"
   if [ -r "${HOME}/.dircolors" ]; then
     eval "$(dircolors -b "${HOME}/.dircolors")"
   elif [ -r "${issl_dircolors_path}" ]; then

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -38,3 +38,16 @@ if command -v colordiff >/dev/null 2>&1; then
 else
   alias diff='diff -u' # Unified diff without color.
 fi
+
+# ===== Functions ===== #
+
+man() {
+  env \
+    LESS_TERMCAP_md="$(printf '\033[01;36m')" \
+    LESS_TERMCAP_me="$(printf '\033[0m')" \
+    LESS_TERMCAP_us="$(printf '\033[01;32m')" \
+    LESS_TERMCAP_ue="$(printf '\033[0m')" \
+    LESS_TERMCAP_so="$(printf '\033[45;93m')" \
+    LESS_TERMCAP_se="$(printf '\033[0m')" \
+    command man "$@"
+}

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -4,9 +4,12 @@
 
 # Configure GNU-style color output for common tools when available.
 if command -v dircolors >/dev/null 2>&1; then
-  # Prefer user-provided color palette when ~/.dircolors exists.
+  # Prefer ~/.dircolors, then the shared ISSL file.
+  issl_dircolors_path="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/.dircolors"
   if [ -r "${HOME}/.dircolors" ]; then
     eval "$(dircolors -b "${HOME}/.dircolors")"
+  elif [ -r "${issl_dircolors_path}" ]; then
+    eval "$(dircolors -b "${issl_dircolors_path}")"
   else
     # Fall back to system default LS_COLORS.
     eval "$(dircolors -b)"

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -1,1 +1,37 @@
 # shellcheck shell=sh
+
+# ===== Aliases ===== #
+
+# Configure GNU-style color output for common tools when available.
+if command -v dircolors >/dev/null 2>&1; then
+  # Prefer user-provided color palette when ~/.dircolors exists.
+  if [ -r "${HOME}/.dircolors" ]; then
+    eval "$(dircolors -b "${HOME}/.dircolors")"
+  else
+    # Fall back to system default LS_COLORS.
+    eval "$(dircolors -b)"
+  fi
+
+  alias ls='ls --color=auto'       # Colorize directory listings.
+  alias dir='dir --color=auto'     # Colorize dir output.
+  alias vdir='vdir --color=auto'   # Colorize verbose dir output.
+  alias grep='grep --color=auto'   # Highlight grep matches.
+  alias fgrep='fgrep --color=auto' # Highlight fixed-string grep matches.
+  alias egrep='egrep --color=auto' # Highlight extended-regex grep matches.
+fi
+
+alias rm='rm -i' # Ask before file removal.
+alias mv='mv -i' # Ask before overwrite on move.
+alias cp='cp -i' # Ask before overwrite on copy.
+
+alias ll='ls -lhF'   # Long list with human-readable sizes.
+alias la='ls -A'     # Show all except . and ...
+alias lla='ls -lhFA' # Long list including hidden files except . and ...
+alias lr='ls -R'     # Recursive listing.
+
+# Use colordiff when available, otherwise keep unified diff output.
+if command -v colordiff >/dev/null 2>&1; then
+  alias diff='colordiff -u' # Unified diff with color.
+else
+  alias diff='diff -u' # Unified diff without color.
+fi

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -56,5 +56,5 @@ man() {
     LESS_TERMCAP_ue="$(printf '\033[0m')" \
     LESS_TERMCAP_so="$(printf '\033[45;93m')" \
     LESS_TERMCAP_se="$(printf '\033[0m')" \
-    command man "$@"
+    man "$@"
 }

--- a/assets/zsh/.zprofile
+++ b/assets/zsh/.zprofile
@@ -1,6 +1,8 @@
 # shellcheck shell=sh
 # shellcheck disable=SC1091
 
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh"
+issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
+
+if [ -f "${issl_bootstrap_shell_home}/env.sh" ]; then
+  . "${issl_bootstrap_shell_home}/env.sh"
 fi

--- a/assets/zsh/.zshrc
+++ b/assets/zsh/.zshrc
@@ -1,12 +1,10 @@
 # shellcheck shell=sh
 # shellcheck disable=SC1091
 
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/env.sh"
-fi
+issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 
-if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh" ]; then
-  . "${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell/rc.sh"
+if [ -f "${issl_bootstrap_shell_home}/rc.sh" ]; then
+  . "${issl_bootstrap_shell_home}/rc.sh"
 fi
 
 # ===== History ===== #

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -10,6 +10,7 @@
     file = {
       ".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
       ".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;
+      ".config/issl/shell/.dircolors".source = ../assets/shell/.dircolors;
       ".config/issl/bash/.bash_profile".source = ../assets/bash/.bash_profile;
       ".config/issl/bash/.bashrc".source = ../assets/bash/.bashrc;
     };

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -1,7 +1,12 @@
-_:
+{ pkgs, ... }:
 
 {
   home = {
+    packages = [
+      pkgs.colordiff
+      pkgs.coreutils
+    ];
+
     file = {
       ".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
       ".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -3,6 +3,7 @@
 {
   home = {
     packages = [
+      pkgs.bash-completion
       pkgs.colordiff
       pkgs.coreutils
     ];

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -8,10 +8,12 @@ nix_profile_share="${home_dir}/.nix-profile/share"
 default_zdotdir="${home_dir}/.zsh"
 issl_enable_zsh="${ISSL_ENABLE_ZSH:?ISSL_ENABLE_ZSH is required}"
 
-assert_shared_shell_env() {
+assert_shared_shell_assets() {
   cmp --silent assets/shell/env.sh "${config_dir}/issl/shell/env.sh"
   cmp --silent assets/shell/rc.sh "${config_dir}/issl/shell/rc.sh"
   cmp --silent assets/shell/.dircolors "${config_dir}/issl/shell/.dircolors"
+  cmp --silent assets/bash/.bash_profile "${config_dir}/issl/bash/.bash_profile"
+  cmp --silent assets/bash/.bashrc "${config_dir}/issl/bash/.bashrc"
 }
 
 assert_shell_env_can_be_sourced() {
@@ -67,7 +69,7 @@ assert_zsh_disabled() {
 }
 
 main() {
-  assert_shared_shell_env
+  assert_shared_shell_assets
   assert_shell_env_can_be_sourced
   assert_bash_startup_files
   assert_shared_shell_tools

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -10,6 +10,7 @@ issl_enable_zsh="${ISSL_ENABLE_ZSH:?ISSL_ENABLE_ZSH is required}"
 assert_shared_shell_env() {
   cmp --silent assets/shell/env.sh "${config_dir}/issl/shell/env.sh"
   cmp --silent assets/shell/rc.sh "${config_dir}/issl/shell/rc.sh"
+  cmp --silent assets/shell/.dircolors "${config_dir}/issl/shell/.dircolors"
 }
 
 assert_shell_env_can_be_sourced() {

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -34,11 +34,15 @@ assert_bash_startup_files() {
 }
 
 assert_shared_shell_tools() {
-  test -x "${nix_profile_bin}/colordiff"
-  test -x "${nix_profile_bin}/dircolors"
   test -f "${nix_profile_share}/bash-completion/bash_completion"
+
+  test -x "${nix_profile_bin}/colordiff"
   test "$(command -v colordiff)" = "${nix_profile_bin}/colordiff"
+  colordiff --version
+
+  test -x "${nix_profile_bin}/dircolors"
   test "$(command -v dircolors)" = "${nix_profile_bin}/dircolors"
+  dircolors --version
 }
 
 assert_zsh_enabled() {

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
+nix_profile_share="${home_dir}/.nix-profile/share"
 default_zdotdir="${home_dir}/.zsh"
 issl_enable_zsh="${ISSL_ENABLE_ZSH:?ISSL_ENABLE_ZSH is required}"
 
@@ -32,6 +33,14 @@ assert_bash_startup_files() {
   grep -Fq "${config_dir}/issl/bash/.bashrc" "${home_dir}/.bashrc"
 }
 
+assert_shared_shell_tools() {
+  test -x "${nix_profile_bin}/colordiff"
+  test -x "${nix_profile_bin}/dircolors"
+  test -f "${nix_profile_share}/bash-completion/bash_completion"
+  test "$(command -v colordiff)" = "${nix_profile_bin}/colordiff"
+  test "$(command -v dircolors)" = "${nix_profile_bin}/dircolors"
+}
+
 assert_zsh_enabled() {
   test -x "${nix_profile_bin}/zsh"
 }
@@ -57,6 +66,7 @@ main() {
   assert_shared_shell_env
   assert_shell_env_can_be_sourced
   assert_bash_startup_files
+  assert_shared_shell_tools
 
   if [ "${issl_enable_zsh}" = "1" ]; then
     assert_zsh_enabled


### PR DESCRIPTION
## Summary
- add shared interactive aliases and `man` color settings in `assets/shell/rc.sh`
- add shared `.dircolors` asset under `assets/shell` and wire it through Home Manager
- add `bash-completion`, `colordiff`, and `coreutils` to shell packages
- streamline shell bootstrap variables so `env.sh` remains the single source of `ISSL_*` definitions

## Testing
- prek hooks passed during commits and targeted runs for updated shell assets/modules/tests