### PR TITLE
ci(shell): include shell dotfiles in lint discovery

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,10 @@ jobs:
               - '**/*.sh'
               - '**/*.bash'
               - '**/*.zsh'
+              - 'assets/bash/.bash_profile'
+              - 'assets/bash/.bashrc'
+              - 'assets/zsh/.zprofile'
+              - 'assets/zsh/.zshrc'
             md:
               - '**/*.md'
               - .markdownlint-cli2.yaml
@@ -189,7 +193,15 @@ jobs:
         shell: bash
         run: |
           shell_files_path="$(mktemp)"
-          find . -type f -name '*.sh' -not -path './.git/*' -print0 > "${shell_files_path}"
+          find . -type f \( \
+            -name '*.sh' -o \
+            -name '*.bash' -o \
+            -name '*.zsh' -o \
+            -path './assets/bash/.bash_profile' -o \
+            -path './assets/bash/.bashrc' -o \
+            -path './assets/zsh/.zprofile' -o \
+            -path './assets/zsh/.zshrc' \
+          \) -not -path './.git/*' -print0 > "${shell_files_path}"
           echo "shell_files=${shell_files_path}" >> "$GITHUB_OUTPUT"
           if [ ! -s "${shell_files_path}" ]; then
             echo "No shell scripts found."

--- a/assets/zsh/.zshrc
+++ b/assets/zsh/.zshrc
@@ -9,13 +9,13 @@ fi
 
 # ===== History ===== #
 
-export HISTFILE="${ZDOTDIR}/.zsh_history"  # Store history under the active ZDOTDIR.
-export HISTSIZE=1000                       # Keep up to 1000 commands in memory.
-export SAVEHIST=10000                      # Persist up to 10000 commands to HISTFILE.
+export HISTFILE="${ZDOTDIR}/.zsh_history" # Store history under the active ZDOTDIR.
+export HISTSIZE=1000                      # Keep up to 1000 commands in memory.
+export SAVEHIST=10000                     # Persist up to 10000 commands to HISTFILE.
 
-setopt append_history        # Append history entries instead of overwriting the file.
-setopt extended_history      # Record execution timestamps in history entries.
-setopt hist_ignore_all_dups  # Remove older duplicates when a command repeats.
-setopt hist_ignore_space     # Skip commands that start with a space.
-setopt hist_reduce_blanks    # Compress redundant internal whitespace before saving.
-setopt share_history         # Share history across concurrent zsh sessions.
+setopt append_history       # Append history entries instead of overwriting the file.
+setopt extended_history     # Record execution timestamps in history entries.
+setopt hist_ignore_all_dups # Remove older duplicates when a command repeats.
+setopt hist_ignore_space    # Skip commands that start with a space.
+setopt hist_reduce_blanks   # Compress redundant internal whitespace before saving.
+setopt share_history        # Share history across concurrent zsh sessions.

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -9,9 +9,9 @@ shared_bash_profile_path="${issl_config_home}/bash/.bash_profile"
 shared_bashrc_path="${issl_config_home}/bash/.bashrc"
 shared_zprofile_path="${issl_config_home}/zsh/.zprofile"
 shared_zshrc_path="${issl_config_home}/zsh/.zshrc"
-git_user_name="${GIT_USER_NAME:-}"
-git_user_email="${GIT_USER_EMAIL:-}"
-issl_enable_zsh="${ISSL_ENABLE_ZSH:-}"
+git_user_name="${GIT_USER_NAME-}"
+git_user_email="${GIT_USER_EMAIL-}"
+issl_enable_zsh="${ISSL_ENABLE_ZSH-}"
 nix_feature_config="experimental-features = nix-command flakes"
 hm_profile_dir="${XDG_STATE_HOME:-$HOME/.local/state}/nix/profiles"
 
@@ -198,14 +198,14 @@ ensure_home_manager_profile_dir() {
 }
 
 is_yes() {
-  case "${1:-}" in
+  case "${1-}" in
   y | Y | yes | YES | Yes | true | TRUE | True | 1) return 0 ;;
   *) return 1 ;;
   esac
 }
 
 is_no() {
-  case "${1:-}" in
+  case "${1-}" in
   n | N | no | NO | No | false | FALSE | False | 0) return 0 ;;
   *) return 1 ;;
   esac
@@ -226,7 +226,7 @@ should_enable_zsh() {
     exit 1
   fi
 
-  current_shell_name="$(basename "${SHELL:-}")"
+  current_shell_name="$(basename "${SHELL-}")"
   if [ "${current_shell_name}" = "zsh" ]; then
     return 0
   fi
@@ -244,7 +244,7 @@ if ! command -v nix >/dev/null 2>&1; then
   exit 1
 fi
 
-if [ -n "${NIX_CONFIG:-}" ]; then
+if [ -n "${NIX_CONFIG-}" ]; then
   export NIX_CONFIG="${NIX_CONFIG}"$'\n'"${nix_feature_config}"
 else
   export NIX_CONFIG="${nix_feature_config}"


### PR DESCRIPTION
### Motivation
- Improve CI shell linting coverage by including user shell dotfiles and additional shell file extensions so that configuration files are validated by `shfmt`/`shellcheck`.

### Description
- Added `assets/bash/.bash_profile`, `assets/bash/.bashrc`, `assets/zsh/.zprofile`, and `assets/zsh/.zshrc` to the `files_yaml` shell group in `.github/workflows/ci.yaml` so changes to those dotfiles trigger the shell linting group.
- Extended the shell discovery `find` invocation to include `*.bash` and `*.zsh` file extensions and explicit paths for the listed asset dotfiles so they are collected for linting.
- Kept existing exclusions for `./.git/*` and preserved the shfmt and shellcheck invocation steps unchanged.

Closes #50 