### PR TITLE
chore(renovate): automerge minor updates for renovate package

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -143,6 +143,19 @@
       automerge: true,
     },
     {
+      matchDepNames: [
+        'renovate',
+      ],
+      matchFileNames: [
+        '.github/workflows/ci.yaml',
+        '.github/workflows/ci.yml',
+      ],
+      matchUpdateTypes: [
+        'minor',
+      ],
+      automerge: true,
+    },
+    {
       matchManagers: [
         'pre-commit',
       ],


### PR DESCRIPTION
## Summary
- add a package rule to auto-merge minor updates for the renovate package only
- keep the existing patch auto-merge policy for other dependency updates
- limit this exception to CI workflow renovate extraction targets

## Why
The renovate package ships frequent minor releases with small changes, so allowing minor auto-merge only for this package reduces maintenance overhead.

## Validation
- pre-commit hooks passed on commit and push