### PR TITLE
feat(rust): add rust toolchain setup and shell integration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,3 +110,9 @@ jobs:
           HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
           CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
         run: ./tests/test-python.sh
+
+      - name: Test rust setup
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+        run: ./tests/test-rust.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -115,4 +115,5 @@ jobs:
         shell: bash
         env:
           HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
         run: ./tests/test-rust.sh

--- a/assets/bash/.bashrc
+++ b/assets/bash/.bashrc
@@ -7,9 +7,19 @@ if [[ -f "${issl_bootstrap_shell_home}/rc.sh" ]]; then
   source "${issl_bootstrap_shell_home}/rc.sh"
 fi
 
+# ===== Completion ===== #
+
 # Enable bash completion from Home Manager profile when available.
 if [[ -f "${ISSL_NIX_PROFILE_PATH}/share/bash-completion/bash_completion" ]]; then
   source "${ISSL_NIX_PROFILE_PATH}/share/bash-completion/bash_completion"
 elif [[ -f "/etc/bash_completion" ]]; then
   source "/etc/bash_completion"
+fi
+
+# Enable rustup/cargo completion when rustup is available.
+if command -v rustup >/dev/null 2>&1; then
+  eval "$(rustup completions bash)"
+  if rustup completions bash cargo >/dev/null 2>&1; then
+    eval "$(rustup completions bash cargo)"
+  fi
 fi

--- a/assets/rust/config.toml
+++ b/assets/rust/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -18,6 +18,7 @@ prepend_path() {
 }
 
 prepend_path "$HOME/.local/bin"
+prepend_path "$HOME/.cargo/bin"
 
 # ===== Python ===== #
 

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -3,8 +3,10 @@
 export ISSL_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
 export ISSL_SHELL_HOME="${ISSL_CONFIG_HOME}/shell"
 export ISSL_PYTHON_HOME="${ISSL_CONFIG_HOME}/python"
+export ISSL_RUST_HOME="${ISSL_CONFIG_HOME}/rust"
 
 export ISSL_NIX_PROFILE_PATH="${ISSL_NIX_PROFILE_PATH:-$HOME/.nix-profile}"
+export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
 
 # Prepend one existing directory to PATH if it is not already present.
 prepend_path() {
@@ -18,7 +20,7 @@ prepend_path() {
 }
 
 prepend_path "$HOME/.local/bin"
-prepend_path "$HOME/.cargo/bin"
+prepend_path "${CARGO_HOME}/bin"
 
 # ===== Python ===== #
 

--- a/assets/zsh/.zshrc
+++ b/assets/zsh/.zshrc
@@ -19,3 +19,16 @@ setopt hist_ignore_all_dups # Remove older duplicates when a command repeats.
 setopt hist_ignore_space    # Skip commands that start with a space.
 setopt hist_reduce_blanks   # Compress redundant internal whitespace before saving.
 setopt share_history        # Share history across concurrent zsh sessions.
+
+# ===== Completion ===== #
+
+# shellcheck disable=SC3044
+autoload -Uz compinit
+compinit
+
+if command -v rustup >/dev/null 2>&1; then
+  eval "$(rustup completions zsh)"
+  if rustup completions zsh cargo >/dev/null 2>&1; then
+    eval "$(rustup completions zsh cargo)"
+  fi
+fi

--- a/home-modules/common.nix
+++ b/home-modules/common.nix
@@ -5,5 +5,6 @@ _:
     ./shell.nix
     ./git.nix
     ./python.nix
+    ./rust.nix
   ];
 }

--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -5,6 +5,7 @@
     packages = [
       pkgs.cargo
       pkgs.cargo-about
+      pkgs.rust-analyzer
       pkgs.rustc
       pkgs.rustup
     ];

--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -3,6 +3,7 @@
 {
   home.packages = [
     pkgs.cargo
+    pkgs.cargo-about
     pkgs.rustc
     pkgs.rustup
   ];

--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -4,7 +4,6 @@
   home = {
     packages = [
       pkgs.cargo-about
-      pkgs.rust-analyzer
       pkgs.rustup
     ];
 

--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.cargo
+    pkgs.rustc
+    pkgs.rustup
+  ];
+}

--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -1,10 +1,14 @@
 { pkgs, ... }:
 
 {
-  home.packages = [
-    pkgs.cargo
-    pkgs.cargo-about
-    pkgs.rustc
-    pkgs.rustup
-  ];
+  home = {
+    packages = [
+      pkgs.cargo
+      pkgs.cargo-about
+      pkgs.rustc
+      pkgs.rustup
+    ];
+
+    file.".config/issl/rust/config.toml".source = ../assets/rust/config.toml;
+  };
 }

--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -3,10 +3,8 @@
 {
   home = {
     packages = [
-      pkgs.cargo
       pkgs.cargo-about
       pkgs.rust-analyzer
-      pkgs.rustc
       pkgs.rustup
     ];
 

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -307,6 +307,21 @@ ensure_cargo_config_include() {
     "$(cargo_config_include_block)"
 }
 
+ensure_rustup_default_stable() {
+  if ! command -v rustup >/dev/null 2>&1; then
+    echo "rustup is required before configuring the Rust toolchain." >&2
+    exit 1
+  fi
+
+  if ! rustup show active-toolchain >/dev/null 2>&1; then
+    rustup toolchain install stable
+  fi
+
+  if ! rustup show active-toolchain | grep -Eq '^stable(-|$)'; then
+    rustup default stable
+  fi
+}
+
 if ! command -v nix >/dev/null 2>&1; then
   echo "nix is required before running scripts/apply.sh." >&2
   exit 1
@@ -343,5 +358,6 @@ ensure_git_include
 prompt_for_git_identity
 ensure_python_startup_file
 ensure_cargo_config_include
+ensure_rustup_default_stable
 
 echo "Applied the shared Home Manager configuration."

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -9,6 +9,7 @@ shared_bash_profile_path="${issl_config_home}/bash/.bash_profile"
 shared_bashrc_path="${issl_config_home}/bash/.bashrc"
 shared_zprofile_path="${issl_config_home}/zsh/.zprofile"
 shared_zshrc_path="${issl_config_home}/zsh/.zshrc"
+shared_rust_config_path="${issl_config_home}/rust/config.toml"
 git_user_name="${GIT_USER_NAME-}"
 git_user_email="${GIT_USER_EMAIL-}"
 issl_enable_zsh="${ISSL_ENABLE_ZSH-}"
@@ -274,6 +275,38 @@ ensure_python_startup_file() {
     "$(pythonrc_block)"
 }
 
+# ===== Rust ===== #
+
+cargo_config_include_block() {
+  printf '%s\n' \
+    "include = [" \
+    "  { path = \"${shared_rust_config_path}\", optional = true }," \
+    "]"
+}
+
+ensure_cargo_config_include() {
+  local cargo_home_path="${CARGO_HOME:-$HOME/.cargo}"
+  local cargo_config_path="${cargo_home_path}/config.toml"
+
+  mkdir -p "${cargo_home_path}"
+
+  if [ -f "${cargo_config_path}" ] && grep -Fq "${shared_rust_config_path}" "${cargo_config_path}"; then
+    return
+  fi
+
+  if [ -f "${cargo_config_path}" ] && grep -Eq '^[[:space:]]*include[[:space:]]*=' "${cargo_config_path}"; then
+    echo "Skipping Cargo include setup because ${cargo_config_path} already defines include." >&2
+    echo "Please add ${shared_rust_config_path} to include manually." >&2
+    return
+  fi
+
+  prepend_block_once \
+    "${cargo_config_path}" \
+    "# >>> ISSL cargo config >>>" \
+    "# <<< ISSL cargo config <<<" \
+    "$(cargo_config_include_block)"
+}
+
 if ! command -v nix >/dev/null 2>&1; then
   echo "nix is required before running scripts/apply.sh." >&2
   exit 1
@@ -309,5 +342,6 @@ fi
 ensure_git_include
 prompt_for_git_identity
 ensure_python_startup_file
+ensure_cargo_config_include
 
 echo "Applied the shared Home Manager configuration."

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -11,12 +11,6 @@ assert_cargo_about_installation() {
   cargo-about --version
 }
 
-assert_rust_analyzer_installation() {
-  test -x "${nix_profile_bin}/rust-analyzer"
-  test "$(command -v rust-analyzer)" = "${nix_profile_bin}/rust-analyzer"
-  rust-analyzer --version
-}
-
 assert_rustup_installation() {
   test -x "${nix_profile_bin}/rustup"
   test "$(command -v rustup)" = "${nix_profile_bin}/rustup"
@@ -48,7 +42,6 @@ assert_cargo_config_include() {
 
 main() {
   assert_cargo_about_installation
-  assert_rust_analyzer_installation
   assert_rustup_installation
   assert_cargo_installation
   assert_rustc_installation

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+home_dir="${HOME_DIR:?HOME_DIR is required}"
+nix_profile_bin="${home_dir}/.nix-profile/bin"
+
+assert_cargo_installation() {
+  test -x "${nix_profile_bin}/cargo"
+  test "$(command -v cargo)" = "${nix_profile_bin}/cargo"
+  cargo --version
+}
+
+assert_rustc_installation() {
+  test -x "${nix_profile_bin}/rustc"
+  test "$(command -v rustc)" = "${nix_profile_bin}/rustc"
+  rustc --version
+}
+
+assert_rustup_installation() {
+  test -x "${nix_profile_bin}/rustup"
+  test "$(command -v rustup)" = "${nix_profile_bin}/rustup"
+  rustup --version
+}
+
+main() {
+  assert_cargo_installation
+  assert_rustc_installation
+  assert_rustup_installation
+}
+
+main "$@"

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
+config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 
 assert_cargo_installation() {
@@ -28,11 +29,26 @@ assert_rustup_installation() {
   rustup --version
 }
 
+assert_shared_rust_config_asset() {
+  cmp --silent assets/rust/config.toml "${config_dir}/issl/rust/config.toml"
+}
+
+assert_cargo_config_include() {
+  local cargo_config_path="${home_dir}/.cargo/config.toml"
+
+  test -f "${cargo_config_path}"
+  grep -Fq '# >>> ISSL cargo config >>>' "${cargo_config_path}"
+  grep -Fq '# <<< ISSL cargo config <<<' "${cargo_config_path}"
+  grep -Fq "${config_dir}/issl/rust/config.toml" "${cargo_config_path}"
+}
+
 main() {
   assert_cargo_installation
   assert_cargo_about_installation
   assert_rustc_installation
   assert_rustup_installation
+  assert_shared_rust_config_asset
+  assert_cargo_config_include
 }
 
 main "$@"

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -5,12 +5,6 @@ home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 
-assert_cargo_installation() {
-  test -x "${nix_profile_bin}/cargo"
-  test "$(command -v cargo)" = "${nix_profile_bin}/cargo"
-  cargo --version
-}
-
 assert_cargo_about_installation() {
   test -x "${nix_profile_bin}/cargo-about"
   test "$(command -v cargo-about)" = "${nix_profile_bin}/cargo-about"
@@ -23,16 +17,20 @@ assert_rust_analyzer_installation() {
   rust-analyzer --version
 }
 
-assert_rustc_installation() {
-  test -x "${nix_profile_bin}/rustc"
-  test "$(command -v rustc)" = "${nix_profile_bin}/rustc"
-  rustc --version
-}
-
 assert_rustup_installation() {
   test -x "${nix_profile_bin}/rustup"
   test "$(command -v rustup)" = "${nix_profile_bin}/rustup"
   rustup --version
+}
+
+assert_cargo_installation() {
+  command -v cargo >/dev/null 2>&1
+  cargo --version
+}
+
+assert_rustc_installation() {
+  command -v rustc >/dev/null 2>&1
+  rustc --version
 }
 
 assert_shared_rust_config_asset() {
@@ -49,11 +47,11 @@ assert_cargo_config_include() {
 }
 
 main() {
-  assert_cargo_installation
   assert_cargo_about_installation
   assert_rust_analyzer_installation
-  assert_rustc_installation
   assert_rustup_installation
+  assert_cargo_installation
+  assert_rustc_installation
   assert_shared_rust_config_asset
   assert_cargo_config_include
 }

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -10,6 +10,12 @@ assert_cargo_installation() {
   cargo --version
 }
 
+assert_cargo_about_installation() {
+  test -x "${nix_profile_bin}/cargo-about"
+  test "$(command -v cargo-about)" = "${nix_profile_bin}/cargo-about"
+  cargo-about --version
+}
+
 assert_rustc_installation() {
   test -x "${nix_profile_bin}/rustc"
   test "$(command -v rustc)" = "${nix_profile_bin}/rustc"
@@ -24,6 +30,7 @@ assert_rustup_installation() {
 
 main() {
   assert_cargo_installation
+  assert_cargo_about_installation
   assert_rustc_installation
   assert_rustup_installation
 }

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -17,6 +17,12 @@ assert_cargo_about_installation() {
   cargo-about --version
 }
 
+assert_rust_analyzer_installation() {
+  test -x "${nix_profile_bin}/rust-analyzer"
+  test "$(command -v rust-analyzer)" = "${nix_profile_bin}/rust-analyzer"
+  rust-analyzer --version
+}
+
 assert_rustc_installation() {
   test -x "${nix_profile_bin}/rustc"
   test "$(command -v rustc)" = "${nix_profile_bin}/rustc"
@@ -45,6 +51,7 @@ assert_cargo_config_include() {
 main() {
   assert_cargo_installation
   assert_cargo_about_installation
+  assert_rust_analyzer_installation
   assert_rustc_installation
   assert_rustup_installation
   assert_shared_rust_config_asset

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -26,6 +26,8 @@ assert_shell_env_can_be_sourced() {
 . "${SHELL_ENV_PATH}"
 test "${ISSL_CONFIG_HOME}" = "${XDG_CONFIG_HOME}/issl"
 test "${ISSL_PYTHON_HOME}" = "${XDG_CONFIG_HOME}/issl/python"
+test "${ISSL_RUST_HOME}" = "${XDG_CONFIG_HOME}/issl/rust"
+test "${CARGO_HOME}" = "${HOME}/.cargo"
 test "${PYTHONSTARTUP}" = "${HOME}/.python/.pythonrc.py"
 test "${PYTHONHISTFILE}" = "${HOME}/.python/.python_history"
 EOF


### PR DESCRIPTION
- add rust toolchain packages via Home Manager (`cargo`, `cargo-about`, `rustc`, `rustup`, `rust-analyzer`)
- add rust setup tests and wire them into workflow
- enable rustup/cargo completion for both bash and zsh
- manage Cargo config via shared include (`$CARGO_HOME/config.toml` -> ISSL rust config)
- set `CARGO_HOME` in shared shell env and use it for PATH composition