### PR TITLE
feat(cpp): add C/C++ baseline toolchain and shared clang-format

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,6 +104,12 @@ jobs:
           CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
         run: ./tests/test-git.sh
 
+      - name: Test C/C++ setup
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+        run: ./tests/test-cpp.sh
+
       - name: Test python setup
         shell: bash
         env:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -11,6 +11,7 @@ rules:
     ignore: |
       .github/workflows/*.yml
       .github/workflows/*.yaml
+      assets/cpp/clang-format.yaml
   comments:
     ignore: |
       .github/workflows/*.yml

--- a/assets/cpp/clang-format.yaml
+++ b/assets/cpp/clang-format.yaml
@@ -1,0 +1,307 @@
+---
+Language: Cpp
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: true
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: true
+AlignConsecutiveDeclarations:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: true
+AlignConsecutiveMacros:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: true
+AlignConsecutiveShortCaseStatements:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterExternBlock: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: None
+BreakArrays: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
+ColumnLimit: 150
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<ext/.*\.h>'
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^<.*\.h>'
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^<.*'
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '.*'
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: false
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  BinaryMinDigits: 0
+  Decimal: 0
+  DecimalMinDigits: 0
+  Hex: 0
+  HexMinDigits: 0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: false
+  AtStartOfFile: true
+LambdaBodyIndentation: Signature
+LineEnding: DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: NextLine
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+PPIndentWidth: -1
+QualifierAlignment: Leave
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle: google
+ReferenceAlignment: Pointer
+ReflowComments: true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes: CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts: false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TableGenBreakInsideDAGArg: DontBreak
+TabWidth: 8
+UseTab: Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -46,6 +46,8 @@ else
   alias diff='diff -u' # Unified diff without color.
 fi
 
+alias makej='make -j$(( $(nproc 2>/dev/null || echo 1) + 1 ))' # Build in parallel with CPU cores + 1 jobs.
+
 # ===== Functions ===== #
 
 man() {

--- a/home-modules/common.nix
+++ b/home-modules/common.nix
@@ -4,6 +4,7 @@ _:
   imports = [
     ./shell.nix
     ./git.nix
+    ./cpp.nix
     ./python.nix
     ./rust.nix
   ];

--- a/home-modules/cpp.nix
+++ b/home-modules/cpp.nix
@@ -7,6 +7,7 @@
       pkgs.gnumake
       pkgs.cmake
       pkgs.clang-tools
+      pkgs.pkg-config
     ];
 
     file.".clang-format".source = ../assets/cpp/clang-format.yaml;

--- a/home-modules/cpp.nix
+++ b/home-modules/cpp.nix
@@ -1,10 +1,14 @@
 { pkgs, ... }:
 
 {
-  home.packages = [
-    pkgs.gcc_multi
-    pkgs.gnumake
-    pkgs.cmake
-    pkgs.clang-tools
-  ];
+  home = {
+    packages = [
+      pkgs.gcc_multi
+      pkgs.gnumake
+      pkgs.cmake
+      pkgs.clang-tools
+    ];
+
+    file.".clang-format".source = ../assets/cpp/clang-format.yaml;
+  };
 }

--- a/home-modules/cpp.nix
+++ b/home-modules/cpp.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.gcc_multi
+    pkgs.gnumake
+    pkgs.cmake
+    pkgs.clang-tools
+  ];
+}

--- a/tests/test-cpp.sh
+++ b/tests/test-cpp.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+home_dir="${HOME_DIR:?HOME_DIR is required}"
+nix_profile_bin="${home_dir}/.nix-profile/bin"
+
+assert_gcc_installation() {
+  test -x "${nix_profile_bin}/gcc"
+  test "$(command -v gcc)" = "${nix_profile_bin}/gcc"
+  gcc --version
+}
+
+assert_gxx_installation() {
+  test -x "${nix_profile_bin}/g++"
+  test "$(command -v g++)" = "${nix_profile_bin}/g++"
+  g++ --version
+}
+
+assert_multilib_support() {
+  gcc -print-multi-lib | grep -Eq '(^|;)32'
+  g++ -print-multi-lib | grep -Eq '(^|;)32'
+}
+
+assert_make_installation() {
+  test -x "${nix_profile_bin}/make"
+  test "$(command -v make)" = "${nix_profile_bin}/make"
+  make --version
+}
+
+assert_cmake_installation() {
+  test -x "${nix_profile_bin}/cmake"
+  test "$(command -v cmake)" = "${nix_profile_bin}/cmake"
+  cmake --version
+}
+
+assert_clang_format_installation() {
+  test -x "${nix_profile_bin}/clang-format"
+  test "$(command -v clang-format)" = "${nix_profile_bin}/clang-format"
+  clang-format --version
+}
+
+main() {
+  assert_gcc_installation
+  assert_gxx_installation
+  assert_multilib_support
+  assert_make_installation
+  assert_cmake_installation
+  assert_clang_format_installation
+}
+
+main "$@"

--- a/tests/test-cpp.sh
+++ b/tests/test-cpp.sh
@@ -39,6 +39,10 @@ assert_clang_format_installation() {
   clang-format --version
 }
 
+assert_shared_clang_format_configuration() {
+  cmp --silent assets/cpp/clang-format.yaml "${home_dir}/.clang-format"
+}
+
 main() {
   assert_gcc_installation
   assert_gxx_installation
@@ -46,6 +50,7 @@ main() {
   assert_make_installation
   assert_cmake_installation
   assert_clang_format_installation
+  assert_shared_clang_format_configuration
 }
 
 main "$@"

--- a/tests/test-cpp.sh
+++ b/tests/test-cpp.sh
@@ -39,6 +39,12 @@ assert_clang_format_installation() {
   clang-format --version
 }
 
+assert_pkg_config_installation() {
+  test -x "${nix_profile_bin}/pkg-config"
+  test "$(command -v pkg-config)" = "${nix_profile_bin}/pkg-config"
+  pkg-config --version
+}
+
 assert_shared_clang_format_configuration() {
   cmp --silent assets/cpp/clang-format.yaml "${home_dir}/.clang-format"
 }
@@ -50,6 +56,7 @@ main() {
   assert_make_installation
   assert_cmake_installation
   assert_clang_format_installation
+  assert_pkg_config_installation
   assert_shared_clang_format_configuration
 }
 


### PR DESCRIPTION
- add C/C++ baseline tools via Home Manager (`gcc_multi`, `gnumake`, `cmake`, `clang-tools`, `pkg-config`)
- add shared `~/.clang-format` distribution from repo asset
- add C/C++ setup test script and wire it into workflow
- add `makej` alias for parallel make execution
- validate `pkg-config` and clang-format config deployment in tests