### PR TITLE
chore(renovate): track ruff version in CI workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -115,6 +115,17 @@
       datasourceTemplate: 'pypi',
       depNameTemplate: 'yamllint',
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.github/workflows/ci\\.ya?ml$/',
+      ],
+      matchStrings: [
+        'ruff==(?<currentValue>[^"\\s]+)',
+      ],
+      datasourceTemplate: 'pypi',
+      depNameTemplate: 'ruff',
+    },
   ],
   packageRules: [
     {


### PR DESCRIPTION
## Summary
- add a Renovate regex manager for ruff version pins in .github/workflows/ci.yaml