### PR TITLE
refactor(flake): move zsh module switch into common module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,10 +37,12 @@
         in
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
+          extraSpecialArgs = {
+            inherit enableZsh;
+          };
           modules = [
             ./home-modules/common.nix
           ]
-          ++ nixpkgs.lib.optional enableZsh ./home-modules/zsh.nix
           ++ [
             {
               home = {

--- a/home-modules/common.nix
+++ b/home-modules/common.nix
@@ -1,12 +1,14 @@
-_:
+{ lib, enableZsh, ... }:
 
 {
-  imports = [
-    ./shell.nix
-    ./vim.nix
-    ./git.nix
-    ./cpp.nix
-    ./python.nix
-    ./rust.nix
-  ];
+  imports =
+    [
+      ./shell.nix
+      ./vim.nix
+      ./git.nix
+      ./cpp.nix
+      ./python.nix
+      ./rust.nix
+    ]
+    ++ lib.optional enableZsh ./zsh.nix;
 }


### PR DESCRIPTION
## Summary
- pass enableZsh via extraSpecialArgs in flake.nix
- move zsh module selection into home-modules/common.nix
- keep behavior unchanged for both common and zsh variants