### PR TITLE
refactor(home): migrate shared config paths to xdg.configFile

### DIFF
--- a/home-modules/git.nix
+++ b/home-modules/git.nix
@@ -1,9 +1,7 @@
 { pkgs, ... }:
 
 {
-  home = {
-    packages = [ pkgs.git ];
+  home.packages = [ pkgs.git ];
 
-    file.".config/issl/git/.gitconfig".source = ../assets/git/.gitconfig;
-  };
+  xdg.configFile."issl/git/.gitconfig".source = ../assets/git/.gitconfig;
 }

--- a/home-modules/main.nix
+++ b/home-modules/main.nix
@@ -1,6 +1,8 @@
 { lib, enableZsh, ... }:
 
 {
+  xdg.enable = true;
+
   imports =
     [
       ./shell.nix

--- a/home-modules/python.nix
+++ b/home-modules/python.nix
@@ -1,9 +1,7 @@
 { pkgs, ... }:
 
 {
-  home = {
-    packages = [ pkgs.uv ];
+  home.packages = [ pkgs.uv ];
 
-    file.".config/issl/python/pythonrc.py".source = ../assets/python/pythonrc.py;
-  };
+  xdg.configFile."issl/python/pythonrc.py".source = ../assets/python/pythonrc.py;
 }

--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -1,12 +1,10 @@
 { pkgs, ... }:
 
 {
-  home = {
-    packages = [
-      pkgs.cargo-about
-      pkgs.rustup
-    ];
+  home.packages = [
+    pkgs.cargo-about
+    pkgs.rustup
+  ];
 
-    file.".config/issl/rust/config.toml".source = ../assets/rust/config.toml;
-  };
+  xdg.configFile."issl/rust/config.toml".source = ../assets/rust/config.toml;
 }

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -1,19 +1,17 @@
 { pkgs, ... }:
 
 {
-  home = {
-    packages = [
-      pkgs.bash-completion
-      pkgs.colordiff
-      pkgs.coreutils
-    ];
+  home.packages = [
+    pkgs.bash-completion
+    pkgs.colordiff
+    pkgs.coreutils
+  ];
 
-    file = {
-      ".config/issl/shell/env.sh".source = ../assets/shell/env.sh;
-      ".config/issl/shell/rc.sh".source = ../assets/shell/rc.sh;
-      ".config/issl/shell/.dircolors".source = ../assets/shell/.dircolors;
-      ".config/issl/bash/.bash_profile".source = ../assets/bash/bash_profile.bash;
-      ".config/issl/bash/.bashrc".source = ../assets/bash/bashrc.bash;
-    };
+  xdg.configFile = {
+    "issl/shell/env.sh".source = ../assets/shell/env.sh;
+    "issl/shell/rc.sh".source = ../assets/shell/rc.sh;
+    "issl/shell/.dircolors".source = ../assets/shell/.dircolors;
+    "issl/bash/.bash_profile".source = ../assets/bash/bash_profile.bash;
+    "issl/bash/.bashrc".source = ../assets/bash/bashrc.bash;
   };
 }

--- a/home-modules/zsh.nix
+++ b/home-modules/zsh.nix
@@ -1,12 +1,10 @@
 { pkgs, ... }:
 
 {
-  home = {
-    packages = [ pkgs.zsh ];
+  home.packages = [ pkgs.zsh ];
 
-    file = {
-      ".config/issl/zsh/.zprofile".source = ../assets/zsh/zprofile.zsh;
-      ".config/issl/zsh/.zshrc".source = ../assets/zsh/zshrc.zsh;
-    };
+  xdg.configFile = {
+    "issl/zsh/.zprofile".source = ../assets/zsh/zprofile.zsh;
+    "issl/zsh/.zshrc".source = ../assets/zsh/zshrc.zsh;
   };
 }


### PR DESCRIPTION
## Summary
- enable XDG support in the main Home Manager module (`xdg.enable = true`)
- migrate shared file mapping from `home.file` to `xdg.configFile` in shell/zsh/git/python/rust modules
- keep deployed paths unchanged under `~/.config/issl/...`
