### PR TITLE
fix(bash): load ~/.bashrc from shared bash_profile

### DIFF
--- a/assets/bash/bash_profile.bash
+++ b/assets/bash/bash_profile.bash
@@ -6,3 +6,8 @@ issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 if [[ -f "${issl_bootstrap_shell_home}/env.sh" ]]; then
   source "${issl_bootstrap_shell_home}/env.sh"
 fi
+
+# Ensure interactive login shells also load ~/.bashrc.
+if [[ $- == *i* ]] && [[ -f "${HOME}/.bashrc" ]]; then
+  source "${HOME}/.bashrc"
+fi

--- a/assets/bash/bashrc.bash
+++ b/assets/bash/bashrc.bash
@@ -1,6 +1,11 @@
 # shellcheck shell=bash
 # shellcheck disable=SC1091
 
+if [[ ${ISSL_BASHRC_LOADED:-0} == "1" ]]; then
+  return 0
+fi
+export ISSL_BASHRC_LOADED=1
+
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 
 if [[ -f "${issl_bootstrap_shell_home}/rc.sh" ]]; then

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -1,5 +1,10 @@
 # shellcheck shell=sh
 
+if [ "${ISSL_ENV_SH_LOADED:-0}" = "1" ]; then
+  return 0
+fi
+export ISSL_ENV_SH_LOADED=1
+
 export ISSL_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
 export ISSL_SHELL_HOME="${ISSL_CONFIG_HOME}/shell"
 export ISSL_PYTHON_HOME="${ISSL_CONFIG_HOME}/python"

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -1,6 +1,11 @@
 # shellcheck shell=sh
 # shellcheck disable=SC1091
 
+if [ "${ISSL_RC_SH_LOADED:-0}" = "1" ]; then
+  return 0
+fi
+export ISSL_RC_SH_LOADED=1
+
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 
 if [ -f "${issl_bootstrap_shell_home}/env.sh" ]; then

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -1,6 +1,11 @@
 # shellcheck shell=sh
 # shellcheck disable=SC1091
 
+if [ "${ISSL_ZSHRC_LOADED:-0}" = "1" ]; then
+  return 0
+fi
+export ISSL_ZSHRC_LOADED=1
+
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 
 if [ -f "${issl_bootstrap_shell_home}/rc.sh" ]; then


### PR DESCRIPTION
## Summary
- source `~/.bashrc` from shared `bash_profile` for interactive login shells
- keep interactive guard to avoid loading rc-only aliases/completions in non-interactive shells

## Why
- when setup creates `~/.bash_profile`, some environments stop reading `~/.profile`
- this can prevent `~/.bashrc` from loading
