### PR TITLE
fix(apply): show zsh login-shell prompt when zsh is enabled

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -266,10 +266,6 @@ maybe_switch_login_shell_to_zsh() {
   local active_login_shell=""
   local response=""
 
-  if [ -z "${issl_enable_zsh}" ] || ! is_yes "${issl_enable_zsh}"; then
-    return
-  fi
-
   if [ ! -t 0 ]; then
     echo "warning: skipping login shell switch prompt because this run is non-interactive." >&2
     return


### PR DESCRIPTION
## Summary
- remove redundant `ISSL_ENABLE_ZSH` env-variable gate from `maybe_switch_login_shell_to_zsh`
- keep prompting behavior tied to actual zsh enablement (`zsh_enabled=1`)

## Why
- users who answer "yes" to the zsh enable prompt should receive the login-shell switch prompt
- previously this prompt was skipped unless `ISSL_ENABLE_ZSH` env var was explicitly set
