### PR TITLE
ci(toml): use pinned taplo binary and reorganize renovate managers

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -99,10 +99,10 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        'taplo-cli@(?<currentValue>\\S+)',
+        "TAPLO_VERSION: '(?<currentValue>[^']+)'",
       ],
-      datasourceTemplate: 'crate',
-      depNameTemplate: 'taplo-cli',
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'tamasfe/taplo',
     },
     {
       customType: 'regex',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,39 +19,6 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/^\\.github/workflows/.*\\.ya?ml$/',
-      ],
-      matchStrings: [
-        "uses: zizmorcore/zizmor-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '(?<currentValue>[^'\\s]+)'",
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'zizmorcore/zizmor',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^\\.github/workflows/.*\\.ya?ml$/',
-      ],
-      matchStrings: [
-        "uses: reviewdog/action-setup@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+reviewdog_version: '(?<currentValue>[^'\\s]+)'",
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'reviewdog/reviewdog',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^\\.github/workflows/.*\\.ya?ml$/',
-      ],
-      matchStrings: [
-        "uses: j178/prek-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+prek-version: '(?<currentValue>[^'\\s]+)'",
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'j178/prek',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
@@ -59,6 +26,17 @@
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'rhysd/actionlint',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.github/workflows/ci\\.ya?ml$/',
+      ],
+      matchStrings: [
+        "uses: zizmorcore/zizmor-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '(?<currentValue>[^'\\s]+)'",
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'zizmorcore/zizmor',
     },
     {
       customType: 'regex',
@@ -81,6 +59,17 @@
       ],
       datasourceTemplate: 'npm',
       depNameTemplate: 'markdownlint-cli2',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.github/workflows/ci\\.ya?ml$/',
+      ],
+      matchStrings: [
+        "uses: reviewdog/action-setup@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+reviewdog_version: '(?<currentValue>[^'\\s]+)'",
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'reviewdog/reviewdog',
     },
     {
       customType: 'regex',
@@ -125,6 +114,17 @@
       ],
       datasourceTemplate: 'pypi',
       depNameTemplate: 'ruff',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.github/workflows/ci\\.ya?ml$/',
+      ],
+      matchStrings: [
+        "uses: j178/prek-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+prek-version: '(?<currentValue>[^'\\s]+)'",
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'j178/prek',
     },
   ],
   packageRules: [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -325,7 +325,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Taplo
-        run: cargo install taplo-cli@0.10.0 --locked
+        env:
+          TAPLO_VERSION: '0.10.0'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+            | gzip -d > "$HOME/.local/bin/taplo"
+          chmod +x "$HOME/.local/bin/taplo"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check TOML format
         run: taplo fmt --check


### PR DESCRIPTION
- install taplo from pinned GitHub release binary in CI
- track TAPLO_VERSION via Renovate (github-releases: tamasfe/taplo)
- reorder Renovate customManagers by workflow scope and CI usage order