### PR TITLE
docs(readme): add publicization status and doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/relea
 
 ## Documentation
 
+- Users: User Guide (TBW).
 - Developers: see [Developer Guide](docs/developer-guide.md).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 A repository for distributing a reproducible and maintainable shared Ubuntu environment for ISSL.
 
+> [!WARNING]
+> This repository is an early-stage prototype and is under active development.
+> It may be made private or deleted without prior notice.
+> It is provided as-is, without user support or compatibility guarantees.
+> Use it at your own risk.
+
 ## Quick Setup
 
 Bootstrap the ISSL Ubuntu environment with a single command:
@@ -27,6 +33,10 @@ To override setup variables, set them before the command. For example, to change
 INSTALL_DIR="$HOME/.local/share/issl/custom-ubuntu-environment-setup" \
 bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/latest/download/setup.sh)
 ```
+
+## Documentation
+
+- Developers: see [Developer Guide](docs/developer-guide.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Bootstrap the ISSL Ubuntu environment with a single command:
 bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/latest/download/setup.sh)
 ```
 
-To pin the setup to a fixed release instead of `latest`, replace `latest` with a release tag such as `v0.1.1`:
+To pin the setup to a fixed release instead of `latest`, replace `latest` with a release tag such as `v0.1.2`:
 
 ```bash
-bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/download/v0.1.1/setup.sh)
+bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/download/v0.1.2/setup.sh)
 ```
 
 To override setup variables, set them before the command. For example, to change the clone destination:
 
 ```bash
-INSTALL_DIR="$HOME/.local/share/issl/custom-ubuntu-environment-setup" \
+INSTALL_DIR="$HOME/.issl-ubuntu-environment-setup" \
 bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/latest/download/setup.sh)
 ```
 


### PR DESCRIPTION
## Summary
- add a warning section clarifying prototype status and support expectations
- mention potential private/deletion status change without prior notice
- refresh quick-setup examples (release tag and INSTALL_DIR example)
- add documentation pointers, including a user guide placeholder (TBW)

## Notes
This is a docs-only change for improving readiness before making the repository public.