### PR TITLE
chore(renovate): group shared tool pins, unify depNames, gate zizmor image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -182,6 +182,12 @@
       groupName: 'yamllint',
     },
     {
+      matchDepNames: [
+        'ghcr.io/zizmorcore/zizmor',
+      ],
+      minimumReleaseAge: '4 days',
+    },
+    {
       matchFileNames: [
         '.github/workflows/**',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,7 +16,8 @@
         "\\n\\s+version: '(?<currentValue>[^'\\s]+)'",
       ],
       datasourceTemplate: 'pypi',
-      depNameTemplate: 'commitizen',
+      depNameTemplate: 'commitizen-tools/commitizen',
+      packageNameTemplate: 'commitizen',
     },
     {
       customType: 'regex',
@@ -40,7 +41,8 @@
         'renovate@(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'npm',
-      depNameTemplate: 'renovate',
+      depNameTemplate: 'renovatebot/renovate',
+      packageNameTemplate: 'renovate',
     },
     {
       customType: 'regex',
@@ -51,7 +53,8 @@
         'markdownlint-cli2@(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'npm',
-      depNameTemplate: 'markdownlint-cli2',
+      depNameTemplate: 'DavidAnson/markdownlint-cli2',
+      packageNameTemplate: 'markdownlint-cli2',
     },
     {
       customType: 'regex',
@@ -75,7 +78,8 @@
         'json5@(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'npm',
-      depNameTemplate: 'json5',
+      depNameTemplate: 'json5/json5',
+      packageNameTemplate: 'json5',
     },
     {
       customType: 'regex',
@@ -99,7 +103,8 @@
         'yamllint==(?<currentValue>[^"\\s]+)',
       ],
       datasourceTemplate: 'pypi',
-      depNameTemplate: 'yamllint',
+      depNameTemplate: 'adrienverge/yamllint',
+      packageNameTemplate: 'yamllint',
     },
     {
       customType: 'regex',
@@ -110,7 +115,8 @@
         'ruff==(?<currentValue>[^"\\s]+)',
       ],
       datasourceTemplate: 'pypi',
-      depNameTemplate: 'ruff',
+      depNameTemplate: 'astral-sh/ruff',
+      packageNameTemplate: 'ruff',
     },
     {
       customType: 'regex',
@@ -163,7 +169,7 @@
     },
     {
       matchDepNames: [
-        'renovate',
+        'renovatebot/renovate',
       ],
       matchFileNames: [
         '.github/workflows/ci.yaml',
@@ -175,7 +181,7 @@
     },
     {
       matchDepNames: [
-        'renovate',
+        'renovatebot/renovate',
       ],
       matchFileNames: [
         '.github/workflows/ci.yaml',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -143,6 +143,45 @@
       allowedVersions: '/^v?\\d+\\.\\d+\\.\\d+$/',
     },
     {
+      matchDepNames: [
+        'commitizen-tools/commitizen',
+      ],
+      groupName: 'commitizen',
+    },
+    {
+      matchDepNames: [
+        'DavidAnson/markdownlint-cli2',
+      ],
+      groupName: 'markdownlint-cli2',
+    },
+    {
+      matchDepNames: [
+        'astral-sh/ruff',
+        'astral-sh/ruff-pre-commit',
+      ],
+      groupName: 'ruff',
+    },
+    {
+      matchDepNames: [
+        'tombi-toml/setup-tombi',
+        'tombi-toml/tombi',
+        'tombi-toml/tombi-pre-commit',
+      ],
+      groupName: 'tombi',
+    },
+    {
+      matchDepNames: [
+        'crate-ci/typos',
+      ],
+      groupName: 'typos',
+    },
+    {
+      matchDepNames: [
+        'adrienverge/yamllint',
+      ],
+      groupName: 'yamllint',
+    },
+    {
       matchFileNames: [
         '.github/workflows/**',
       ],


### PR DESCRIPTION
Apply three improvements to the renovate.json5:

1. **Unify customManager depNames to `org/name`** (with `packageNameTemplate` preserving the npm/pypi lookup), matching the form Renovate derives for pre-commit hooks.
2. **Group the pre-commit and CI pins of shared tools** (commitizen, markdownlint-cli2, ruff, tombi, typos, yamllint), sorted alphabetically.
3. **Hold the zizmor image one day longer than the action** (`minimumReleaseAge: 4 days`) so the image never becomes eligible before the matching `zizmor-action`, avoiding version-mismatch CI failures.
