### PR TITLE
ci(nix): add nixfmt pre-commit hook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -539,6 +539,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check prek
         uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,11 @@
 default_stages: [pre-commit]
 
 repos:
+  - repo: https://github.com/NixOS/nixfmt
+    rev: 3245f221e4d9ab7e12ebe31fd193cb7a8c4b14f9  # frozen: v1.3.1
+    hooks:
+      - id: nixfmt-nix
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 77039ccbba72c8aede339c5f8ae29b42aced0a2e  # frozen: v0.15.18
     hooks:


### PR DESCRIPTION
- Add the official NixOS `nixfmt` pre-commit hook.
- Use `nixfmt-nix` so the hook runs through local Nix instead of requiring Cabal.

