### PR TITLE
ci: enable zizmor advanced-security for public repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,12 @@ jobs:
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
           version: 'v1.24.1'
-          advanced-security: false  # must be false for private repo
+          advanced-security: >-
+            ${{
+              github.event.repository.private == false &&
+              (github.event_name != 'pull_request' ||
+              github.event.pull_request.head.repo.full_name == github.repository)
+            }}
 
   validate-renovate-config:
     name: Validate Renovate config


### PR DESCRIPTION
Compute the zizmor `advanced-security` flag dynamically instead of hard-coding it to `false`.

- Enabled when the repository is public and the run is not a fork pull request.
- Avoids enabling advanced security where it is unavailable (private repos, fork PRs).
