### PR TITLE
feat(nix): install the home-manager CLI in the shared configuration

### DIFF
--- a/home-modules/nix.nix
+++ b/home-modules/nix.nix
@@ -2,4 +2,6 @@ _:
 
 {
   xdg.configFile."issl/nix/nix.conf".source = ../assets/nix/nix.conf;
+
+  programs.home-manager.enable = true;
 }

--- a/tests/test-nix.sh
+++ b/tests/test-nix.sh
@@ -28,11 +28,16 @@ assert_nix_command_available_without_extra_flags() {
     nix profile list >/dev/null
 }
 
+assert_home_manager_installation() {
+  command -v home-manager >/dev/null
+}
+
 main() {
   assert_nix_installation
   assert_shared_nix_config
   assert_nix_conf_include
   assert_nix_command_available_without_extra_flags
+  assert_home_manager_installation
 }
 
 main "$@"


### PR DESCRIPTION
Enable `programs.home-manager` in the Nix module so the `home-manager` command is installed into the profile on switch.

`tests/test-nix.sh` now asserts the command is available.
