### PR TITLE
chore(renovate): enable nix manager for flake.lock updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -253,6 +253,9 @@
   'pre-commit': {
     enabled: true,
   },
+  nix: {
+    enabled: true,
+  },
   labels: [
     'automated',
     'dependencies',


### PR DESCRIPTION
Enable Renovate's `nix` manager so `flake.lock` is kept up to date automatically.

- The `nix` manager is in beta and disabled by default, so it must be opted in explicitly.
- `lockFileMaintenance` is already enabled via `config:best-practices` (`:maintainLockFilesWeekly`), so no extra setting is needed. Once the manager is enabled, the `nixpkgs` and `home-manager` inputs in `flake.lock` are refreshed weekly.
