### PR TITLE
feat(rust): bootstrap the stable toolchain via Home Manager activation

### DIFF
--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 {
   home.packages = [
@@ -7,4 +7,14 @@
   ];
 
   xdg.configFile."issl/rust/config.toml".source = ../assets/rust/config.toml;
+
+  home.activation.rustupDefaultStable = lib.hm.dag.entryAfter [ "installPackages" ] ''
+    rustup=${pkgs.rustup}/bin/rustup
+    if ! "$rustup" show active-toolchain >/dev/null 2>&1; then
+      run "$rustup" toolchain install stable
+    fi
+    if ! "$rustup" show active-toolchain 2>/dev/null | grep -Eq '^stable(-|$)'; then
+      run "$rustup" default stable
+    fi
+  '';
 }

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -495,21 +495,6 @@ ensure_cargo_config_include() {
     "$(cargo_config_include_block)"
 }
 
-ensure_rustup_default_stable() {
-  if ! command -v rustup >/dev/null 2>&1; then
-    echo "rustup is required before configuring the Rust toolchain." >&2
-    exit 1
-  fi
-
-  if ! rustup show active-toolchain >/dev/null 2>&1; then
-    rustup toolchain install stable
-  fi
-
-  if ! rustup show active-toolchain | grep -Eq '^stable(-|$)'; then
-    rustup default stable
-  fi
-}
-
 if ! command -v nix >/dev/null 2>&1; then
   echo "nix is required before running scripts/apply.sh." >&2
   exit 1
@@ -550,6 +535,5 @@ ensure_git_include
 prompt_for_git_identity
 ensure_python_startup_file
 ensure_cargo_config_include
-ensure_rustup_default_stable
 
 echo "Applied the shared Home Manager configuration."

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -27,6 +27,10 @@ assert_rustc_installation() {
   rustc --version
 }
 
+assert_default_toolchain_stable() {
+  rustup show active-toolchain | grep -Eq '^stable(-|$)'
+}
+
 assert_shared_rust_config_asset() {
   cmp --silent assets/rust/config.toml "${config_dir}/issl/rust/config.toml"
 }
@@ -45,6 +49,7 @@ main() {
   assert_rustup_installation
   assert_cargo_installation
   assert_rustc_installation
+  assert_default_toolchain_stable
   assert_shared_rust_config_asset
   assert_cargo_config_include
 }

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -5,6 +5,8 @@ home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 
+export RUSTUP_HOME="${home_dir}/.rustup"
+
 assert_cargo_about_installation() {
   test -x "${nix_profile_bin}/cargo-about"
   test "$(command -v cargo-about)" = "${nix_profile_bin}/cargo-about"


### PR DESCRIPTION
Move the stable toolchain bootstrap out of `scripts/apply.sh` and into the shared `rust.nix` as a `home.activation` script.

Previously only the script-based workflow installed and defaulted the stable toolchain, so the personal-config (`home-manager switch`) workflow ended up with `rustup` but no toolchain. Running it during activation makes both workflows converge on the same final state.

- Add a `home.activation` script that installs and defaults the stable toolchain (idempotent, same guard as before).
- Drop the now-redundant `ensure_rustup_default_stable` from `apply.sh`.
- Assert in `tests/test-rust.sh` that the default toolchain is stable.
