### PR TITLE
feat: refine shared shell and git defaults

### DIFF
--- a/assets/bash/bashrc.bash
+++ b/assets/bash/bashrc.bash
@@ -12,6 +12,15 @@ if [[ -f "${issl_bootstrap_shell_home}/rc.sh" ]]; then
   source "${issl_bootstrap_shell_home}/rc.sh"
 fi
 
+# ===== History ===== #
+
+export HISTSIZE=1000                         # Keep up to 1000 commands in memory.
+export HISTFILESIZE=10000                    # Persist up to 10000 commands to HISTFILE.
+export HISTTIMEFORMAT="[%Y-%m-%d %H:%M:%S] " # Show timestamps in history output.
+export HISTCONTROL=ignoreboth:erasedups      # Ignore leading-space commands and duplicate entries.
+
+shopt -s histappend # Append history entries instead of overwriting the file.
+
 # ===== Completion ===== #
 
 # Enable bash completion from Home Manager profile when available.

--- a/assets/git/.gitconfig
+++ b/assets/git/.gitconfig
@@ -1,15 +1,12 @@
 [alias]
-    ch = checkout
-    cr = clone --recursive
-    cm = commit
-    ca = commit --amend
+    amend = commit --amend
     d = diff --summary --stat --patch
     wd = d --word-diff
     stat = diff --stat
     sgl = log --graph --all --decorate --date=format:'%Y/%m/%d %H:%M' --pretty=format:'%C(yellow)%h %C(green)%cd %C(auto)%d %C(white)%s %C(cyan)[%cn]'
     sgls = sgl --stat
-    st = status
     su = submodule update --init --recursive
+    unstage = restore --staged
     which = "!_() { git config --get alias.$1; }; _"
 
 [core]
@@ -21,17 +18,27 @@
 [init]
     defaultBranch = main
 
-[fetch]
-    prune = true
+[status]
+    showStash = true
 
-[pull]
-    rebase = false
+[diff]
+    colorMoved = default
+    colorMovedWS = allow-indentation-change
+
+[merge]
+    conflictStyle = zdiff3
 
 [rebase]
     autoStash = true
 
 [rerere]
     enabled = true
+
+[fetch]
+    prune = true
+
+[pull]
+    rebase = false
 
 [push]
     default = simple
@@ -40,9 +47,3 @@
 
 [tag]
     sort = version:refname
-
-[help]
-    autocorrect = 1
-
-[url "ssh://git@github.com/"]
-    insteadOf = https://github.com/

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -12,7 +12,7 @@ if [ -f "${issl_bootstrap_shell_home}/env.sh" ]; then
   . "${issl_bootstrap_shell_home}/env.sh"
 fi
 
-# ===== Aliases ===== #
+# ===== Functions and Aliases ===== #
 
 # Configure GNU-style color output for common tools when available.
 if command -v dircolors >/dev/null 2>&1; then
@@ -52,8 +52,6 @@ else
 fi
 
 alias makej='make -j$(( $(nproc 2>/dev/null || echo 1) + 1 ))' # Build in parallel with CPU cores + 1 jobs.
-
-# ===== Functions ===== #
 
 man() {
   env \

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -58,6 +58,36 @@ if command -v rustc >/dev/null 2>&1; then
   fi
 fi
 
+# Configure completion styles.
+if [ -n "${LS_COLORS:-}" ]; then
+  # shellcheck disable=SC2086,SC2296
+  zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+fi
+zstyle ':completion:*' auto-description 'specify: %d'
+zstyle ':completion:*' completer _oldlist _expand _complete _correct
+zstyle ':completion:*' group-name ''
+zstyle ':completion:*' ignore-parents parent pwd ..
+zstyle ':completion:*' insert-tab false
+zstyle ':completion:*' list-dirs-first true
+zstyle ':completion:*' list-prompt '%SAt %p: hit TAB for more, or the character to insert%s'
+zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+zstyle ':completion:*' menu select=2
+zstyle ':completion:*' rehash true
+zstyle ':completion:*' select-prompt '%SScrolling active: current selection at %p%s'
+zstyle ':completion:*' squeeze-slashes true
+zstyle ':completion:*' use-compctl false
+zstyle ':completion:*' verbose true
+zstyle ':completion:*:corrections' format '%F{green}%d (errors: %e)%f'
+zstyle ':completion:*:descriptions' format '%B%F{white}--- %d ---%f%b'
+zstyle ':completion:*:messages' format '%F{yellow}%d'
+zstyle ':completion:*:options' description 'yes'
+zstyle ':completion:*:warnings' format '%F{red}No matches for: %F{white}%d%b'
+zstyle ':completion:*:*:git-checkout:*:*' list-colors '=(#b) #([0-9]#)*=0=00;33'
+zstyle ':completion:*:*:git-switch:*:*' list-colors '=(#b) #([0-9]#)*=0=00;33'
+# shellcheck disable=SC2016
+zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=00;31'
+
 # shellcheck disable=SC3044
 autoload -Uz compinit
 compinit

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -73,3 +73,8 @@ fi
 if command -v rustup >/dev/null 2>&1; then
   eval "$(rustup completions zsh)"
 fi
+
+# ===== Functions and Aliases ===== #
+
+autoload -Uz zmv
+alias mmv='noglob zmv -W'

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -25,6 +25,18 @@ setopt hist_ignore_space    # Skip commands that start with a space.
 setopt hist_reduce_blanks   # Compress redundant internal whitespace before saving.
 setopt share_history        # Share history across concurrent zsh sessions.
 
+# ===== Options ===== #
+
+setopt auto_menu            # Show completion menu automatically on ambiguous completion.
+setopt auto_param_keys      # Insert matching parameter expansion syntax during completion.
+setopt complete_in_word     # Complete from both ends of the word around the cursor.
+setopt correct              # Ask before running a command whose name looks misspelled.
+setopt interactive_comments # Allow comments in interactive commands.
+setopt magic_equal_subst    # Expand command arguments after '=' as file names where applicable.
+setopt mark_dirs            # Append a trailing slash to completed directory names.
+setopt no_beep              # Disable terminal beeps from Zsh.
+setopt rm_star_wait         # Add a short delay before confirming dangerous rm globs.
+
 # ===== Completion ===== #
 
 # Add $ZDOTDIR/functions to fpath for user-managed functions and completions.

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -59,9 +59,8 @@ if command -v rustc >/dev/null 2>&1; then
 fi
 
 # Configure completion styles.
-if [ -n "${LS_COLORS:-}" ]; then
-  # shellcheck disable=SC2086,SC2296
-  zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+if [ -n "${LS_COLORS-}" ]; then
+  eval "zstyle ':completion:*:default' list-colors \${(s.:.)LS_COLORS}"
 fi
 zstyle ':completion:*' auto-description 'specify: %d'
 zstyle ':completion:*' completer _oldlist _expand _complete _correct


### PR DESCRIPTION
- Add shared Bash/Zsh history, option, completion, and helper defaults for the common environment.
- Refine shared Git defaults by keeping broadly useful helpers in common, moving personal shorthand and GitHub SSH rewrite behavior out of common, and adding safer diff/conflict/status defaults.
- Keep user-overridable behavior in later configuration layers.
