### PR TITLE
ci: split shell linting into sh/bash and zsh jobs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,20 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
+        'mvdan\\.cc/sh/v3/cmd/shfmt@(?<currentDigest>[a-f0-9]{40}) # (?<currentValue>v[^\\s]+)',
+      ],
+      autoReplaceStringTemplate: 'mvdan.cc/sh/v3/cmd/shfmt@{{{newDigest}}} # {{{newValue}}}',
+      datasourceTemplate: 'github-tags',
+      depNameTemplate: 'mvdan/shfmt',
+      packageNameTemplate: 'mvdan/sh',
+      versioningTemplate: 'semver',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.github/workflows/ci\\.ya?ml$/',
+      ],
+      matchStrings: [
         'markdownlint-cli2@(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'npm',
@@ -160,6 +174,13 @@
         'astral-sh/ruff-pre-commit',
       ],
       groupName: 'ruff',
+    },
+    {
+      matchDepNames: [
+        'mvdan/shfmt',
+        'scop/pre-commit-shfmt',
+      ],
+      groupName: 'shfmt',
     },
     {
       matchDepNames: [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,8 @@ jobs:
       github_actions_ci: ${{ steps.changed-files.outputs.github_actions_ci_any_changed }}
       renovate_config: ${{ steps.changed-files.outputs.renovate_config_any_changed }}
       nix: ${{ steps.changed-files.outputs.nix_any_changed }}
-      shell: ${{ steps.changed-files.outputs.shell_any_changed }}
+      sh_bash: ${{ steps.changed-files.outputs.sh_bash_any_changed }}
+      zsh: ${{ steps.changed-files.outputs.zsh_any_changed }}
       md: ${{ steps.changed-files.outputs.md_any_changed }}
       json5: ${{ steps.changed-files.outputs.json5_any_changed }}
       json5_files: ${{ steps.changed-files.outputs.json5_all_changed_files }}
@@ -53,9 +54,10 @@ jobs:
             nix:
               - '**/*.nix'
               - flake.lock
-            shell:
+            sh_bash:
               - '**/*.sh'
               - '**/*.bash'
+            zsh:
               - '**/*.zsh'
             md:
               - '**/*.md'
@@ -208,11 +210,11 @@ jobs:
             echo "No flake.nix found. Skipping flake check."
           fi
 
-  lint-shell-scripts:
-    name: Lint Shell Scripts
+  lint-sh-bash:
+    name: Lint sh/Bash
     needs: determine-changes
     if: >-
-      ${{ needs.determine-changes.outputs.shell == 'true' ||
+      ${{ needs.determine-changes.outputs.sh_bash == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
     permissions:
@@ -227,46 +229,46 @@ jobs:
           persist-credentials: false
 
       - name: Install shell tools
+        shell: bash
         run: |
+          go install mvdan.cc/sh/v3/cmd/shfmt@2f3f5e36d9b0f8f14c998d50aa20a28832205ae8 # v3.13.1
           sudo apt-get update
-          sudo apt-get install -y shfmt
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             sudo apt-get install -y shellcheck
           fi
 
-      - name: Collect shell scripts
-        id: shell-files
+      - name: Collect sh/bash files
+        id: sh-bash-files
         shell: bash
         run: |
-          shell_files_path="$(mktemp)"
+          sh_bash_files_path="$(mktemp)"
           find . -type f \( \
             -name '*.sh' -o \
-            -name '*.bash' -o \
-            -name '*.zsh' \
-          \) -not -path './.git/*' -print0 > "${shell_files_path}"
-          echo "shell_files=${shell_files_path}" >> "$GITHUB_OUTPUT"
-          if [ ! -s "${shell_files_path}" ]; then
-            echo "No shell scripts found."
+            -name '*.bash' \
+          \) -not -path './.git/*' -print0 > "${sh_bash_files_path}"
+          echo "sh_bash_files=${sh_bash_files_path}" >> "$GITHUB_OUTPUT"
+          if [ ! -s "${sh_bash_files_path}" ]; then
+            echo "No sh/bash files found."
             echo "found=false" >> "$GITHUB_OUTPUT"
           else
             echo "found=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run shfmt
-        if: steps.shell-files.outputs.found == 'true'
+        if: steps.sh-bash-files.outputs.found == 'true'
         shell: bash
         env:
-          SHELL_FILES: ${{ steps.shell-files.outputs.shell_files }}
+          SH_BASH_FILES: ${{ steps.sh-bash-files.outputs.sh_bash_files }}
         run: |
-          xargs -0 shfmt --diff --simplify -i 2 < "${SHELL_FILES}"
+          xargs -0 "$(go env GOPATH)/bin/shfmt" --diff --simplify -i 2 < "${SH_BASH_FILES}"
 
       - name: Run shellcheck
-        if: github.event_name != 'pull_request' && steps.shell-files.outputs.found == 'true'
+        if: github.event_name != 'pull_request' && steps.sh-bash-files.outputs.found == 'true'
         shell: bash
         env:
-          SHELL_FILES: ${{ steps.shell-files.outputs.shell_files }}
+          SH_BASH_FILES: ${{ steps.sh-bash-files.outputs.sh_bash_files }}
         run: |
-          xargs -0 shellcheck --external-sources < "${SHELL_FILES}"
+          xargs -0 shellcheck --external-sources < "${SH_BASH_FILES}"
 
       - name: Run shellcheck (reviewdog)
         if: github.event_name == 'pull_request'
@@ -275,6 +277,62 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           fail_level: error
+          pattern: |
+            *.sh
+            *.bash
+
+  lint-zsh:
+    name: Lint Zsh
+    needs: determine-changes
+    if: >-
+      ${{ needs.determine-changes.outputs.zsh == 'true' ||
+      needs.determine-changes.outputs.github_actions_ci == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the main repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Zsh tools
+        shell: bash
+        run: |
+          go install mvdan.cc/sh/v3/cmd/shfmt@2f3f5e36d9b0f8f14c998d50aa20a28832205ae8 # v3.13.1
+          sudo apt-get update
+          sudo apt-get install -y zsh
+
+      - name: Collect Zsh files
+        id: zsh-files
+        shell: bash
+        run: |
+          zsh_files_path="$(mktemp)"
+          find . -type f -name '*.zsh' -not -path './.git/*' -print0 > "${zsh_files_path}"
+          echo "zsh_files=${zsh_files_path}" >> "$GITHUB_OUTPUT"
+          if [ ! -s "${zsh_files_path}" ]; then
+            echo "No Zsh files found."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run shfmt
+        if: steps.zsh-files.outputs.found == 'true'
+        shell: bash
+        env:
+          ZSH_FILES: ${{ steps.zsh-files.outputs.zsh_files }}
+        run: |
+          xargs -0 "$(go env GOPATH)/bin/shfmt" --language-dialect zsh --diff --simplify -i 2 < "${ZSH_FILES}"
+
+      - name: Check Zsh syntax
+        if: steps.zsh-files.outputs.found == 'true'
+        shell: bash
+        env:
+          ZSH_FILES: ${{ steps.zsh-files.outputs.zsh_files }}
+        run: |
+          xargs -0 -n 1 zsh -n < "${ZSH_FILES}"
 
   lint-markdown:
     name: Lint Markdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     rev: 99470f5e12208ff0fb17ab81c3c494f7620a1d8d  # frozen: v0.11.0
     hooks:
       - id: shellcheck
+        exclude: \.zsh$
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: 996abf60411a8d954288ac9856aae7602b80cbda  # frozen: v0.22.1

--- a/assets/zsh/zprofile.zsh
+++ b/assets/zsh/zprofile.zsh
@@ -1,6 +1,3 @@
-# shellcheck shell=sh
-# shellcheck disable=SC1091
-
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 
 if [ -f "${issl_bootstrap_shell_home}/env.sh" ]; then

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -54,8 +54,8 @@ if command -v rustc >/dev/null 2>&1; then
 fi
 
 # Configure completion styles.
-if [ -n "${LS_COLORS-}" ]; then
-  eval "zstyle ':completion:*:default' list-colors \${(s.:.)LS_COLORS}"
+if [ -n "${LS_COLORS:-}" ]; then
+  zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
 fi
 zstyle ':completion:*' auto-description 'specify: %d'
 zstyle ':completion:*' completer _oldlist _expand _complete _correct

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -1,6 +1,3 @@
-# shellcheck shell=sh
-# shellcheck disable=SC1091
-
 if [ "${ISSL_ZSHRC_LOADED:-0}" = "1" ]; then
   return 0
 fi
@@ -45,7 +42,6 @@ if [ ! -d "${issl_zsh_functions_dir}" ]; then
   mkdir -p "${issl_zsh_functions_dir}" 2>/dev/null || true
 fi
 if [ -d "${issl_zsh_functions_dir}" ]; then
-  # shellcheck disable=SC3030,SC3054
   fpath=("${issl_zsh_functions_dir}" "${fpath[@]}")
 fi
 
@@ -53,7 +49,6 @@ fi
 if command -v rustc >/dev/null 2>&1; then
   issl_rustup_cargo_completion_dir="$(rustc --print sysroot 2>/dev/null)/share/zsh/site-functions"
   if [ -f "${issl_rustup_cargo_completion_dir}/_cargo" ]; then
-    # shellcheck disable=SC3030,SC3054
     fpath=("${issl_rustup_cargo_completion_dir}" "${fpath[@]}")
   fi
 fi
@@ -83,11 +78,9 @@ zstyle ':completion:*:options' description 'yes'
 zstyle ':completion:*:warnings' format '%F{red}No matches for: %F{white}%d%b'
 zstyle ':completion:*:*:git-checkout:*:*' list-colors '=(#b) #([0-9]#)*=0=00;33'
 zstyle ':completion:*:*:git-switch:*:*' list-colors '=(#b) #([0-9]#)*=0=00;33'
-# shellcheck disable=SC2016
 zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=00;31'
 
-# shellcheck disable=SC3044
 autoload -Uz compinit
 compinit
 


### PR DESCRIPTION
Separate the single shell lint job into a sh/bash job and a dedicated Zsh job so each shell family is checked with the appropriate tooling.

- Split the `determine-changes` output into `sh_bash` (`*.sh`, `*.bash`) and `zsh` (`*.zsh`).
- Rename `lint-shell-scripts` to `lint-sh-bash`, scoped to `*.sh`/`*.bash`, keeping `shfmt` and `shellcheck`.
- Add a `lint-zsh` job that runs `shfmt` with the zsh dialect and `zsh -n`, without `shellcheck` (which does not support Zsh).
- Pin `shfmt` to a commit SHA and add a Renovate manager (grouped with the `scop/pre-commit-shfmt` hook).
- Exclude `*.zsh` from the `shellcheck` pre-commit hook and drop the now obsolete `shellcheck` directives from the Zsh files.
