### PR TITLE
feat(zsh): adjust history settings

### DIFF
--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -12,15 +12,18 @@ fi
 # ===== History ===== #
 
 export HISTFILE="${ZDOTDIR}/.zsh_history" # Store history under the active ZDOTDIR.
-export HISTSIZE=1000                      # Keep up to 1000 commands in memory.
-export SAVEHIST=10000                     # Persist up to 10000 commands to HISTFILE.
 
-setopt append_history       # Append history entries instead of overwriting the file.
-setopt extended_history     # Record execution timestamps in history entries.
-setopt hist_ignore_all_dups # Remove older duplicates when a command repeats.
-setopt hist_ignore_space    # Skip commands that start with a space.
-setopt hist_reduce_blanks   # Compress redundant internal whitespace before saving.
-setopt share_history        # Share history across concurrent zsh sessions.
+export HISTSIZE=10000 # Keep up to 10000 commands in memory.
+export SAVEHIST=10000 # Persist up to 10000 commands to HISTFILE.
+
+setopt hist_ignore_space  # Skip commands that start with a space.
+setopt hist_ignore_dups   # Skip recording a command that duplicates the previous one.
+setopt hist_find_no_dups  # Skip duplicates when searching or scrolling history.
+setopt extended_history   # Record execution timestamps in history entries.
+setopt hist_reduce_blanks # Compress redundant internal whitespace before saving.
+setopt append_history     # Append history entries instead of overwriting the file.
+setopt share_history      # Share history across concurrent zsh sessions.
+setopt hist_fcntl_lock    # Lock the history file with fcntl() for safe concurrent access.
 
 # ===== Options ===== #
 


### PR DESCRIPTION
Adjust the zsh history settings:

- Add `hist_fcntl_lock` for safe concurrent history writes.
- Replace `hist_ignore_all_dups` with `hist_ignore_dups` + `hist_find_no_dups`: drop consecutive duplicates while keeping non-consecutive ones on disk, hidden when searching or scrolling.
- Raise `HISTSIZE` to 10000.
