### PR TITLE
ci: validate the shared environment for both setup methods via a reusable workflow

### DIFF
--- a/.github/workflows/test-environment.yaml
+++ b/.github/workflows/test-environment.yaml
@@ -1,0 +1,165 @@
+name: Test environment
+
+on:
+  workflow_call:
+    inputs:
+      setup-mode:
+        required: true
+        type: string
+      common-repository:
+        required: false
+        type: string
+        default: ut-issl/issl-ubuntu-environment-setup
+      common-ref:
+        required: false
+        type: string
+        default: main
+      user-repository:
+        required: false
+        type: string
+        default: ''
+      user-ref:
+        required: false
+        type: string
+        default: ''
+      override-issl-input:
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (${{ matrix.enable_zsh_name }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - enable_zsh: "0"
+            enable_zsh_name: "zsh disabled"
+            flake_target: user
+          - enable_zsh: "1"
+            enable_zsh_name: "zsh enabled"
+            flake_target: user-zsh
+
+    steps:
+      - name: Checkout common repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.common-repository }}
+          ref: ${{ inputs.common-ref }}
+          path: common
+          persist-credentials: false
+
+      - name: Checkout user repository
+        if: inputs.setup-mode == 'repository-based'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.user-repository }}
+          ref: ${{ inputs.user-ref }}
+          path: user
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare test environment
+        id: test-env
+        shell: bash
+        run: |
+          tmpdir="$(mktemp -d)"
+          {
+            echo "home_dir=${tmpdir}/home"
+            echo "config_dir=${tmpdir}/home/.config"
+            echo "data_dir=${tmpdir}/home/.local/share"
+            echo "state_dir=${tmpdir}/home/.local/state"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run apply.sh
+        if: inputs.setup-mode == 'script-based'
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
+          DATA_DIR: ${{ steps.test-env.outputs.data_dir }}
+          STATE_DIR: ${{ steps.test-env.outputs.state_dir }}
+        run: |
+          env \
+            HOME="${HOME_DIR}" \
+            USER="issl-test" \
+            XDG_CONFIG_HOME="${CONFIG_DIR}" \
+            XDG_DATA_HOME="${DATA_DIR}" \
+            XDG_STATE_HOME="${STATE_DIR}" \
+            ISSL_ENABLE_ZSH="${{ matrix.enable_zsh }}" \
+            GIT_USER_NAME="ISSL Test User" \
+            GIT_USER_EMAIL="issl-test@example.com" \
+            bash ./common/scripts/apply.sh
+
+      - name: Apply Home Manager configuration
+        if: inputs.setup-mode == 'repository-based'
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
+          DATA_DIR: ${{ steps.test-env.outputs.data_dir }}
+          STATE_DIR: ${{ steps.test-env.outputs.state_dir }}
+          FLAKE_TARGET: ${{ matrix.flake_target }}
+        run: |
+          cd user
+
+          switch_args=(
+            --impure
+            --show-trace
+          )
+
+          if [ "${{ inputs.override-issl-input }}" = "true" ]; then
+            switch_args+=(
+              --override-input
+              issl
+              "path:${GITHUB_WORKSPACE}/common"
+            )
+          fi
+
+          env \
+            HOME="${HOME_DIR}" \
+            USER="issl-test" \
+            XDG_CONFIG_HOME="${CONFIG_DIR}" \
+            XDG_DATA_HOME="${DATA_DIR}" \
+            XDG_STATE_HOME="${STATE_DIR}" \
+            nix run ".#home-manager" -- \
+              switch --flake ".#${FLAKE_TARGET}" "${switch_args[@]}"
+
+      - name: Add Home Manager profile to PATH
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+        run: echo "${HOME_DIR}/.nix-profile/bin" >> "${GITHUB_PATH}"
+
+      - name: Run environment tests
+        if: inputs.setup-mode == 'script-based'
+        shell: bash
+        env:
+          COMMON_DIR: ${{ github.workspace }}/common
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
+          ISSL_ENABLE_ZSH: ${{ matrix.enable_zsh }}
+          EXPECTED_GIT_USER_NAME: ISSL Test User
+          EXPECTED_GIT_USER_EMAIL: issl-test@example.com
+        run: ./common/tests/run.sh
+
+      - name: Run environment tests
+        if: inputs.setup-mode == 'repository-based'
+        shell: bash
+        env:
+          COMMON_DIR: ${{ github.workspace }}/common
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
+          ISSL_ENABLE_ZSH: ${{ matrix.enable_zsh }}
+        run: ./common/tests/run.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - .github/workflows/test.yaml
+      - .github/workflows/test-environment.yaml
       - assets/**
       - flake.nix
       - flake.lock
@@ -16,6 +17,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - .github/workflows/test.yaml
+      - .github/workflows/test-environment.yaml
       - assets/**
       - flake.nix
       - flake.lock
@@ -31,112 +33,21 @@ permissions:
   contents: read
 
 jobs:
-  install:
-    name: Test apply.sh (${{ matrix.enable_zsh_name }})
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - enable_zsh: "0"
-            enable_zsh_name: "zsh disabled"
-          - enable_zsh: "1"
-            enable_zsh_name: "zsh enabled"
+  apply:
+    name: Test apply.sh
+    uses: ./.github/workflows/test-environment.yaml
+    with:
+      setup-mode: script-based
+      common-repository: ${{ github.repository }}
+      common-ref: ${{ github.sha }}
 
-    steps:
-      - name: Checkout the main repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare test environment
-        id: test-env
-        shell: bash
-        run: |
-          tmpdir="$(mktemp -d)"
-          {
-            echo "home_dir=${tmpdir}/home"
-            echo "config_dir=${tmpdir}/home/.config"
-            echo "data_dir=${tmpdir}/home/.local/share"
-            echo "state_dir=${tmpdir}/home/.local/state"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Run apply.sh
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
-          DATA_DIR: ${{ steps.test-env.outputs.data_dir }}
-          STATE_DIR: ${{ steps.test-env.outputs.state_dir }}
-        run: |
-          env \
-            HOME="${HOME_DIR}" \
-            USER="issl-test" \
-            XDG_CONFIG_HOME="${CONFIG_DIR}" \
-            XDG_DATA_HOME="${DATA_DIR}" \
-            XDG_STATE_HOME="${STATE_DIR}" \
-            ISSL_ENABLE_ZSH="${{ matrix.enable_zsh }}" \
-            GIT_USER_NAME="ISSL Test User" \
-            GIT_USER_EMAIL="issl-test@example.com" \
-            bash ./scripts/apply.sh
-
-      - name: Add Home Manager profile to PATH
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-        run: echo "${HOME_DIR}/.nix-profile/bin" >> "${GITHUB_PATH}"
-
-      - name: Test nix setup
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
-        run: ./tests/test-nix.sh
-
-      - name: Test shell setup
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
-          ISSL_ENABLE_ZSH: ${{ matrix.enable_zsh }}
-        run: ./tests/test-shell.sh
-
-      - name: Test git setup
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
-        run: ./tests/test-git.sh
-
-      - name: Test C/C++ setup
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-        run: ./tests/test-cpp.sh
-
-      - name: Test python setup
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
-        run: ./tests/test-python.sh
-
-      - name: Test rust setup
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
-        run: ./tests/test-rust.sh
-
-      - name: Test vim setup
-        shell: bash
-        env:
-          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
-        run: ./tests/test-vim.sh
+  # user-repo:
+  #   name: Test user repo
+  #   uses: ./.github/workflows/test-environment.yaml
+  #   with:
+  #     setup-mode: repository-based
+  #     common-repository: ${{ github.repository }}
+  #     common-ref: ${{ github.sha }}
+  #     user-repository: ut-issl/personal-nix-config-template
+  #     user-ref: main
+  #     override-issl-input: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   apply:
-    name: Test apply.sh
+    name: Test script-based setup
     uses: ./.github/workflows/test-environment.yaml
     with:
       setup-mode: script-based
@@ -42,7 +42,7 @@ jobs:
       common-ref: ${{ github.sha }}
 
   # user-repo:
-  #   name: Test user repo
+  #   name: Test config-repository-based setup
   #   uses: ./.github/workflows/test-environment.yaml
   #   with:
   #     setup-mode: repository-based

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -16,5 +16,9 @@ rules:
     ignore: |
       .github/workflows/*.yml
       .github/workflows/*.yaml
+  comments-indentation:
+    ignore: |
+      .github/workflows/*.yml
+      .github/workflows/*.yaml
   line-length:
     max: 120

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
-
-cd "${common_dir}"
+common_dir="$(cd -- "${COMMON_DIR:-$(dirname -- "${BASH_SOURCE[0]}")/..}" && pwd)"
+export COMMON_DIR="${common_dir}"
 
 "${common_dir}/tests/test-nix.sh"
 "${common_dir}/tests/test-shell.sh"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+cd "${common_dir}"
+
+"${common_dir}/tests/test-nix.sh"
+"${common_dir}/tests/test-shell.sh"
+"${common_dir}/tests/test-git.sh"
+"${common_dir}/tests/test-cpp.sh"
+"${common_dir}/tests/test-python.sh"
+"${common_dir}/tests/test-rust.sh"
+"${common_dir}/tests/test-vim.sh"

--- a/tests/test-cpp.sh
+++ b/tests/test-cpp.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 
 assert_gcc_installation() {
@@ -46,7 +47,7 @@ assert_pkg_config_installation() {
 }
 
 assert_shared_clang_format_configuration() {
-  cmp --silent assets/cpp/clang-format.yaml "${home_dir}/.clang-format"
+  cmp --silent "${common_dir}/assets/cpp/clang-format.yaml" "${home_dir}/.clang-format"
 }
 
 main() {

--- a/tests/test-git.sh
+++ b/tests/test-git.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 
 assert_git_installation() {
@@ -12,33 +13,34 @@ assert_git_installation() {
 }
 
 assert_shared_git_config() {
-  cmp --silent assets/git/.gitconfig "${config_dir}/issl/git/.gitconfig"
+  cmp --silent "${common_dir}/assets/git/.gitconfig" "${config_dir}/issl/git/.gitconfig"
 }
 
 assert_global_git_include() {
-  local include_path
-  include_path="$(
-    HOME="${home_dir}" XDG_CONFIG_HOME="${config_dir}" \
-      git config --global --get-all include.path
-  )"
-  test "${include_path}" = "${config_dir}/issl/git/.gitconfig"
+  HOME="${home_dir}" XDG_CONFIG_HOME="${config_dir}" \
+    git config --global --get-all include.path |
+    grep -Fx "${config_dir}/issl/git/.gitconfig"
 }
 
 assert_git_identity() {
   local user_name
   local user_email
 
-  user_name="$(
-    HOME="${home_dir}" XDG_CONFIG_HOME="${config_dir}" \
-      git config --global --get user.name
-  )"
-  test "${user_name}" = "ISSL Test User"
+  if [ -n "${EXPECTED_GIT_USER_NAME:-}" ]; then
+    user_name="$(
+      HOME="${home_dir}" XDG_CONFIG_HOME="${config_dir}" \
+        git config --global --get user.name
+    )"
+    test "${user_name}" = "${EXPECTED_GIT_USER_NAME}"
+  fi
 
-  user_email="$(
-    HOME="${home_dir}" XDG_CONFIG_HOME="${config_dir}" \
-      git config --global --get user.email
-  )"
-  test "${user_email}" = "issl-test@example.com"
+  if [ -n "${EXPECTED_GIT_USER_EMAIL:-}" ]; then
+    user_email="$(
+      HOME="${home_dir}" XDG_CONFIG_HOME="${config_dir}" \
+        git config --global --get user.email
+    )"
+    test "${user_email}" = "${EXPECTED_GIT_USER_EMAIL}"
+  fi
 }
 
 main() {

--- a/tests/test-nix.sh
+++ b/tests/test-nix.sh
@@ -18,6 +18,7 @@ assert_shared_nix_config() {
 }
 
 assert_nix_conf_include() {
+  test -f "${nix_config_path}"
   grep -Fq "!include ${issl_nix_config_path}" "${nix_config_path}"
 }
 

--- a/tests/test-nix.sh
+++ b/tests/test-nix.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 nix_config_path="${config_dir}/nix/nix.conf"
 issl_nix_config_path="${config_dir}/issl/nix/nix.conf"
@@ -13,12 +14,10 @@ assert_nix_installation() {
 }
 
 assert_shared_nix_config() {
-  cmp --silent assets/nix/nix.conf "${issl_nix_config_path}"
+  cmp --silent "${common_dir}/assets/nix/nix.conf" "${issl_nix_config_path}"
 }
 
 assert_nix_conf_include() {
-  grep -Fq '# >>> ISSL nix config >>>' "${nix_config_path}"
-  grep -Fq "# <<< ISSL nix config <<<" "${nix_config_path}"
   grep -Fq "!include ${issl_nix_config_path}" "${nix_config_path}"
 }
 

--- a/tests/test-python.sh
+++ b/tests/test-python.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 pythonrc_path="${home_dir}/.python/.pythonrc.py"
 issl_python_home="${config_dir}/issl/python"
@@ -15,13 +16,11 @@ assert_uv_installation() {
 }
 
 assert_shared_pythonrc_asset() {
-  cmp --silent assets/python/pythonrc.py "${issl_pythonrc_path}"
+  cmp --silent "${common_dir}/assets/python/pythonrc.py" "${issl_pythonrc_path}"
 }
 
 assert_user_python_startup_file() {
   test -f "${pythonrc_path}"
-  grep -Fq '# >>> ISSL python startup >>>' "${pythonrc_path}"
-  grep -Fq '# <<< ISSL python startup <<<' "${pythonrc_path}"
   grep -Fq 'runpy.run_path(str(shared_pythonrc), run_name="__main__")' "${pythonrc_path}"
 }
 

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 
 export RUSTUP_HOME="${home_dir}/.rustup"
@@ -34,15 +35,13 @@ assert_default_toolchain_stable() {
 }
 
 assert_shared_rust_config_asset() {
-  cmp --silent assets/rust/config.toml "${config_dir}/issl/rust/config.toml"
+  cmp --silent "${common_dir}/assets/rust/config.toml" "${config_dir}/issl/rust/config.toml"
 }
 
 assert_cargo_config_include() {
   local cargo_config_path="${home_dir}/.cargo/config.toml"
 
   test -f "${cargo_config_path}"
-  grep -Fq '# >>> ISSL cargo config >>>' "${cargo_config_path}"
-  grep -Fq '# <<< ISSL cargo config <<<' "${cargo_config_path}"
   grep -Fq "${config_dir}/issl/rust/config.toml" "${cargo_config_path}"
 }
 

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -35,6 +35,9 @@ EOF
 }
 
 assert_bash_startup_files() {
+  test -f "${home_dir}/.bash_profile"
+  test -f "${home_dir}/.bashrc"
+
   grep -Fq "${config_dir}/issl/bash/.bash_profile" "${home_dir}/.bash_profile"
   grep -Fq "${config_dir}/issl/bash/.bashrc" "${home_dir}/.bashrc"
 }

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -3,17 +3,18 @@ set -euo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 nix_profile_share="${home_dir}/.nix-profile/share"
 default_zdotdir="${home_dir}/.zsh"
 issl_enable_zsh="${ISSL_ENABLE_ZSH:?ISSL_ENABLE_ZSH is required}"
 
 assert_shared_shell_assets() {
-  cmp --silent assets/shell/env.sh "${config_dir}/issl/shell/env.sh"
-  cmp --silent assets/shell/rc.sh "${config_dir}/issl/shell/rc.sh"
-  cmp --silent assets/shell/.dircolors "${config_dir}/issl/shell/.dircolors"
-  cmp --silent assets/bash/bash_profile.bash "${config_dir}/issl/bash/.bash_profile"
-  cmp --silent assets/bash/bashrc.bash "${config_dir}/issl/bash/.bashrc"
+  cmp --silent "${common_dir}/assets/shell/env.sh" "${config_dir}/issl/shell/env.sh"
+  cmp --silent "${common_dir}/assets/shell/rc.sh" "${config_dir}/issl/shell/rc.sh"
+  cmp --silent "${common_dir}/assets/shell/.dircolors" "${config_dir}/issl/shell/.dircolors"
+  cmp --silent "${common_dir}/assets/bash/bash_profile.bash" "${config_dir}/issl/bash/.bash_profile"
+  cmp --silent "${common_dir}/assets/bash/bashrc.bash" "${config_dir}/issl/bash/.bashrc"
 }
 
 assert_shell_env_can_be_sourced() {
@@ -34,9 +35,7 @@ EOF
 }
 
 assert_bash_startup_files() {
-  grep -Fq '# >>> ISSL bash profile >>>' "${home_dir}/.bash_profile"
   grep -Fq "${config_dir}/issl/bash/.bash_profile" "${home_dir}/.bash_profile"
-  grep -Fq '# >>> ISSL bash rc >>>' "${home_dir}/.bashrc"
   grep -Fq "${config_dir}/issl/bash/.bashrc" "${home_dir}/.bashrc"
 }
 
@@ -59,17 +58,16 @@ assert_zsh_enabled() {
 }
 
 assert_shared_zsh_assets() {
-  cmp --silent assets/zsh/zprofile.zsh "${config_dir}/issl/zsh/.zprofile"
-  cmp --silent assets/zsh/zshrc.zsh "${config_dir}/issl/zsh/.zshrc"
+  cmp --silent "${common_dir}/assets/zsh/zprofile.zsh" "${config_dir}/issl/zsh/.zprofile"
+  cmp --silent "${common_dir}/assets/zsh/zshrc.zsh" "${config_dir}/issl/zsh/.zshrc"
 }
 
 assert_default_zsh_startup_files_enabled() {
-  grep -Fq '# >>> ISSL zsh env >>>' "${home_dir}/.zshenv"
-  # shellcheck disable=SC2016
-  grep -Fq 'export ZDOTDIR="$HOME/.zsh"' "${home_dir}/.zshenv"
-  grep -Fq '# >>> ISSL zsh profile >>>' "${default_zdotdir}/.zprofile"
+  test -f "${home_dir}/.zshenv"
+  test -f "${default_zdotdir}/.zprofile"
+  test -f "${default_zdotdir}/.zshrc"
+
   grep -Fq "${config_dir}/issl/zsh/.zprofile" "${default_zdotdir}/.zprofile"
-  grep -Fq '# >>> ISSL zsh rc >>>' "${default_zdotdir}/.zshrc"
   grep -Fq "${config_dir}/issl/zsh/.zshrc" "${default_zdotdir}/.zshrc"
 }
 


### PR DESCRIPTION
Make the environment tests independent of the setup method so the same assertions validate both the script-based setup (`scripts/apply.sh`) and a personal config repository's Home Manager setup.

- Add `tests/run.sh` as a single entrypoint and make each `tests/test-*.sh` resolve shared assets via `COMMON_DIR`, so they pass regardless of the working directory or the setup method.
- Drop the `apply.sh`-specific marker and `ZDOTDIR` assertions, relax the Git include check to a containment match, and make the Git identity assertions opt-in via `EXPECTED_GIT_USER_NAME` / `EXPECTED_GIT_USER_EMAIL`. Add an explicit existence check before the remaining content greps.
- Add a reusable workflow `test-environment.yaml` with `setup-mode=script-based` and `setup-mode=repository-based`, and reduce `test.yaml` to a thin wrapper that calls it. The `repository-based` mode applies the user repo's configuration with `home-manager switch`, mirroring `apply.sh`.

The `repository-based` job is commented out for now because `personal-nix-config-template` is still private and cannot be checked out by the workflow, so only the `script-based` job runs.
