### PR TITLE
test: report failure locations and verify shell startup behaviorally

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+external-sources=true
+source-path=SCRIPTDIR/..

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+# Shared helpers for the ISSL environment tests.
+#
+# Sourcing scripts must enable errtrace (set -E) so the ERR trap below also
+# fires for failures inside functions.
+
+# Report the location and command of the first failing assertion.
+# shellcheck disable=SC2317  # invoked via the ERR trap, not directly.
+_issl_test_failed() {
+  local status=$?
+  printf 'FAILED: %s:%s: %s (exit %s)\n' \
+    "${BASH_SOURCE[1]##*/}" "${BASH_LINENO[0]}" "${BASH_COMMAND}" "${status}" >&2
+}
+trap _issl_test_failed ERR
+
+# Run a named assertion, logging it so progress is visible in the test output.
+run_assert() {
+  printf -- '-- %s\n' "${1}"
+  "$@"
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,10 +4,7 @@ set -euo pipefail
 common_dir="$(cd -- "${COMMON_DIR:-$(dirname -- "${BASH_SOURCE[0]}")/..}" && pwd)"
 export COMMON_DIR="${common_dir}"
 
-"${common_dir}/tests/test-nix.sh"
-"${common_dir}/tests/test-shell.sh"
-"${common_dir}/tests/test-git.sh"
-"${common_dir}/tests/test-cpp.sh"
-"${common_dir}/tests/test-python.sh"
-"${common_dir}/tests/test-rust.sh"
-"${common_dir}/tests/test-vim.sh"
+for name in nix shell git cpp python rust vim; do
+  printf '\n=== tests/test-%s.sh ===\n' "${name}"
+  "${common_dir}/tests/test-${name}.sh"
+done

--- a/tests/test-cpp.sh
+++ b/tests/test-cpp.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
+
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
 
 assert_gcc_installation() {
   test -x "${nix_profile_bin}/gcc"
@@ -47,18 +50,18 @@ assert_pkg_config_installation() {
 }
 
 assert_shared_clang_format_configuration() {
-  cmp --silent "${common_dir}/assets/cpp/clang-format.yaml" "${home_dir}/.clang-format"
+  cmp "${common_dir}/assets/cpp/clang-format.yaml" "${home_dir}/.clang-format"
 }
 
 main() {
-  assert_gcc_installation
-  assert_gxx_installation
-  assert_multilib_support
-  assert_make_installation
-  assert_cmake_installation
-  assert_clang_format_installation
-  assert_pkg_config_installation
-  assert_shared_clang_format_configuration
+  run_assert assert_gcc_installation
+  run_assert assert_gxx_installation
+  run_assert assert_multilib_support
+  run_assert assert_make_installation
+  run_assert assert_cmake_installation
+  run_assert assert_clang_format_installation
+  run_assert assert_pkg_config_installation
+  run_assert assert_shared_clang_format_configuration
 }
 
 main "$@"

--- a/tests/test-git.sh
+++ b/tests/test-git.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
+
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
 
 assert_git_installation() {
   test -x "${nix_profile_bin}/git"
@@ -13,7 +16,7 @@ assert_git_installation() {
 }
 
 assert_shared_git_config() {
-  cmp --silent "${common_dir}/assets/git/.gitconfig" "${config_dir}/issl/git/.gitconfig"
+  cmp "${common_dir}/assets/git/.gitconfig" "${config_dir}/issl/git/.gitconfig"
 }
 
 assert_global_git_include() {
@@ -44,10 +47,10 @@ assert_git_identity() {
 }
 
 main() {
-  assert_git_installation
-  assert_shared_git_config
-  assert_global_git_include
-  assert_git_identity
+  run_assert assert_git_installation
+  run_assert assert_shared_git_config
+  run_assert assert_global_git_include
+  run_assert assert_git_identity
 }
 
 main "$@"

--- a/tests/test-nix.sh
+++ b/tests/test-nix.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
@@ -8,13 +8,16 @@ nix_profile_bin="${home_dir}/.nix-profile/bin"
 nix_config_path="${config_dir}/nix/nix.conf"
 issl_nix_config_path="${config_dir}/issl/nix/nix.conf"
 
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
+
 assert_nix_installation() {
   command -v nix >/dev/null
   nix --version
 }
 
 assert_shared_nix_config() {
-  cmp --silent "${common_dir}/assets/nix/nix.conf" "${issl_nix_config_path}"
+  cmp "${common_dir}/assets/nix/nix.conf" "${issl_nix_config_path}"
 }
 
 assert_nix_conf_include() {
@@ -36,11 +39,11 @@ assert_home_manager_installation() {
 }
 
 main() {
-  assert_nix_installation
-  assert_shared_nix_config
-  assert_nix_conf_include
-  assert_nix_command_available_without_extra_flags
-  assert_home_manager_installation
+  run_assert assert_nix_installation
+  run_assert assert_shared_nix_config
+  run_assert assert_nix_conf_include
+  run_assert assert_nix_command_available_without_extra_flags
+  run_assert assert_home_manager_installation
 }
 
 main "$@"

--- a/tests/test-python.sh
+++ b/tests/test-python.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
@@ -9,6 +9,9 @@ pythonrc_path="${home_dir}/.python/.pythonrc.py"
 issl_python_home="${config_dir}/issl/python"
 issl_pythonrc_path="${issl_python_home}/pythonrc.py"
 
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
+
 assert_uv_installation() {
   test -x "${nix_profile_bin}/uv"
   test "$(command -v uv)" = "${nix_profile_bin}/uv"
@@ -16,7 +19,7 @@ assert_uv_installation() {
 }
 
 assert_shared_pythonrc_asset() {
-  cmp --silent "${common_dir}/assets/python/pythonrc.py" "${issl_pythonrc_path}"
+  cmp "${common_dir}/assets/python/pythonrc.py" "${issl_pythonrc_path}"
 }
 
 assert_user_python_startup_file() {
@@ -42,10 +45,10 @@ assert_python_startup_is_loaded() {
 }
 
 main() {
-  assert_uv_installation
-  assert_shared_pythonrc_asset
-  assert_user_python_startup_file
-  assert_python_startup_is_loaded
+  run_assert assert_uv_installation
+  run_assert assert_shared_pythonrc_asset
+  run_assert assert_user_python_startup_file
+  run_assert assert_python_startup_is_loaded
 }
 
 main "$@"

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
-
 export RUSTUP_HOME="${home_dir}/.rustup"
+
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
 
 assert_cargo_about_installation() {
   test -x "${nix_profile_bin}/cargo-about"
@@ -35,7 +37,7 @@ assert_default_toolchain_stable() {
 }
 
 assert_shared_rust_config_asset() {
-  cmp --silent "${common_dir}/assets/rust/config.toml" "${config_dir}/issl/rust/config.toml"
+  cmp "${common_dir}/assets/rust/config.toml" "${config_dir}/issl/rust/config.toml"
 }
 
 assert_cargo_config_include() {
@@ -46,13 +48,13 @@ assert_cargo_config_include() {
 }
 
 main() {
-  assert_cargo_about_installation
-  assert_rustup_installation
-  assert_cargo_installation
-  assert_rustc_installation
-  assert_default_toolchain_stable
-  assert_shared_rust_config_asset
-  assert_cargo_config_include
+  run_assert assert_cargo_about_installation
+  run_assert assert_rustup_installation
+  run_assert assert_cargo_installation
+  run_assert assert_rustc_installation
+  run_assert assert_default_toolchain_stable
+  run_assert assert_shared_rust_config_asset
+  run_assert assert_cargo_config_include
 }
 
 main "$@"

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -40,9 +40,23 @@ EOF
 assert_bash_startup_files() {
   test -f "${home_dir}/.bash_profile"
   test -f "${home_dir}/.bashrc"
+}
 
-  grep -Fq "${config_dir}/issl/bash/.bash_profile" "${home_dir}/.bash_profile"
-  grep -Fq "${config_dir}/issl/bash/.bashrc" "${home_dir}/.bashrc"
+assert_bash_startup_is_loaded() {
+  # Drive a login + interactive bash and confirm the shared startup files ran,
+  # observed through their load guards.
+  # shellcheck disable=SC2016  # ${...} inside the single-quoted -c argument expand in the subshell.
+  env -i \
+    HOME="${home_dir}" \
+    XDG_CONFIG_HOME="${config_dir}" \
+    PATH="${nix_profile_bin}:/usr/bin:/bin" \
+    TERM=dumb \
+    bash -lic '
+      ok=1
+      [ "${ISSL_ENV_SH_LOADED:-0}" = "1" ] || { echo "login shell did not load the shared env.sh" >&2; ok=0; }
+      [ "${ISSL_BASHRC_LOADED:-0}" = "1" ] || { echo "interactive shell did not load the shared bashrc" >&2; ok=0; }
+      [ "${ok}" = "1" ]
+    '
 }
 
 assert_shared_shell_tools() {
@@ -68,13 +82,25 @@ assert_shared_zsh_assets() {
   cmp "${common_dir}/assets/zsh/zshrc.zsh" "${config_dir}/issl/zsh/.zshrc"
 }
 
-assert_default_zsh_startup_files_enabled() {
+assert_zsh_startup_files() {
   test -f "${home_dir}/.zshenv"
   test -f "${default_zdotdir}/.zprofile"
   test -f "${default_zdotdir}/.zshrc"
+}
 
-  grep -Fq "${config_dir}/issl/zsh/.zprofile" "${default_zdotdir}/.zprofile"
-  grep -Fq "${config_dir}/issl/zsh/.zshrc" "${default_zdotdir}/.zshrc"
+assert_zsh_startup_is_loaded() {
+  # shellcheck disable=SC2016  # ${...} inside the single-quoted -c argument expand in the subshell.
+  env -i \
+    HOME="${home_dir}" \
+    XDG_CONFIG_HOME="${config_dir}" \
+    PATH="${nix_profile_bin}:/usr/bin:/bin" \
+    TERM=dumb \
+    zsh -lic '
+      ok=1
+      [ "${ISSL_ENV_SH_LOADED:-0}" = "1" ] || { echo "login shell did not load the shared env.sh" >&2; ok=0; }
+      [ "${ISSL_ZSHRC_LOADED:-0}" = "1" ] || { echo "interactive shell did not load the shared zshrc" >&2; ok=0; }
+      [ "${ok}" = "1" ]
+    '
 }
 
 assert_zsh_disabled() {
@@ -88,12 +114,14 @@ main() {
   run_assert assert_shared_shell_assets
   run_assert assert_shell_env_can_be_sourced
   run_assert assert_bash_startup_files
+  run_assert assert_bash_startup_is_loaded
   run_assert assert_shared_shell_tools
 
   if [ "${issl_enable_zsh}" = "1" ]; then
     run_assert assert_zsh_enabled
     run_assert assert_shared_zsh_assets
-    run_assert assert_default_zsh_startup_files_enabled
+    run_assert assert_zsh_startup_files
+    run_assert assert_zsh_startup_is_loaded
   else
     run_assert assert_zsh_disabled
   fi

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
@@ -9,12 +9,15 @@ nix_profile_share="${home_dir}/.nix-profile/share"
 default_zdotdir="${home_dir}/.zsh"
 issl_enable_zsh="${ISSL_ENABLE_ZSH:?ISSL_ENABLE_ZSH is required}"
 
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
+
 assert_shared_shell_assets() {
-  cmp --silent "${common_dir}/assets/shell/env.sh" "${config_dir}/issl/shell/env.sh"
-  cmp --silent "${common_dir}/assets/shell/rc.sh" "${config_dir}/issl/shell/rc.sh"
-  cmp --silent "${common_dir}/assets/shell/.dircolors" "${config_dir}/issl/shell/.dircolors"
-  cmp --silent "${common_dir}/assets/bash/bash_profile.bash" "${config_dir}/issl/bash/.bash_profile"
-  cmp --silent "${common_dir}/assets/bash/bashrc.bash" "${config_dir}/issl/bash/.bashrc"
+  cmp "${common_dir}/assets/shell/env.sh" "${config_dir}/issl/shell/env.sh"
+  cmp "${common_dir}/assets/shell/rc.sh" "${config_dir}/issl/shell/rc.sh"
+  cmp "${common_dir}/assets/shell/.dircolors" "${config_dir}/issl/shell/.dircolors"
+  cmp "${common_dir}/assets/bash/bash_profile.bash" "${config_dir}/issl/bash/.bash_profile"
+  cmp "${common_dir}/assets/bash/bashrc.bash" "${config_dir}/issl/bash/.bashrc"
 }
 
 assert_shell_env_can_be_sourced() {
@@ -61,8 +64,8 @@ assert_zsh_enabled() {
 }
 
 assert_shared_zsh_assets() {
-  cmp --silent "${common_dir}/assets/zsh/zprofile.zsh" "${config_dir}/issl/zsh/.zprofile"
-  cmp --silent "${common_dir}/assets/zsh/zshrc.zsh" "${config_dir}/issl/zsh/.zshrc"
+  cmp "${common_dir}/assets/zsh/zprofile.zsh" "${config_dir}/issl/zsh/.zprofile"
+  cmp "${common_dir}/assets/zsh/zshrc.zsh" "${config_dir}/issl/zsh/.zshrc"
 }
 
 assert_default_zsh_startup_files_enabled() {
@@ -82,17 +85,17 @@ assert_zsh_disabled() {
 }
 
 main() {
-  assert_shared_shell_assets
-  assert_shell_env_can_be_sourced
-  assert_bash_startup_files
-  assert_shared_shell_tools
+  run_assert assert_shared_shell_assets
+  run_assert assert_shell_env_can_be_sourced
+  run_assert assert_bash_startup_files
+  run_assert assert_shared_shell_tools
 
   if [ "${issl_enable_zsh}" = "1" ]; then
-    assert_zsh_enabled
-    assert_shared_zsh_assets
-    assert_default_zsh_startup_files_enabled
+    run_assert assert_zsh_enabled
+    run_assert assert_shared_zsh_assets
+    run_assert assert_default_zsh_startup_files_enabled
   else
-    assert_zsh_disabled
+    run_assert assert_zsh_disabled
   fi
 }
 

--- a/tests/test-vim.sh
+++ b/tests/test-vim.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 home_dir="${HOME_DIR:?HOME_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
+
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
 
 assert_vim_installation() {
   test -x "${nix_profile_bin}/vim"
@@ -11,7 +15,7 @@ assert_vim_installation() {
 }
 
 main() {
-  assert_vim_installation
+  run_assert assert_vim_installation
 }
 
 main "$@"


### PR DESCRIPTION
Make the environment tests report where they fail and verify shell startup by behavior rather than by setup-specific file layout.

- Add `tests/lib.sh` with an `ERR` trap that prints the failing file, line, command, and exit status, plus a `run_assert` helper so each assertion is logged as it runs. All test scripts source it and enable `set -E` so the trap fires inside functions.
- Stop silencing `cmp`, so a mismatch shows the differing bytes.
- Split the shell startup checks into file-existence assertions and behavioral load assertions. The behavioral checks launch a login + interactive bash/zsh and confirm the shared startup files were sourced via their load guards, which holds for both the script-based setup and a Home Manager setup (where the bash include lives in `~/.profile`). This fixes the bash assertion that previously assumed the include is written directly into `~/.bash_profile`.
- Add a `.shellcheckrc` so ShellCheck follows the sourced `tests/lib.sh`.
