### PR TITLE
docs: sync tests section with the reusable workflow

### DIFF
--- a/docs/91-repository-structure.md
+++ b/docs/91-repository-structure.md
@@ -79,7 +79,9 @@ Examples:
 - `test-cpp.sh`, `test-vim.sh`, and `test-nix.sh` check the corresponding shared setup.
 
 These tests verify that the expected tools are available and that the shared assets are deployed and referenced correctly.
-They are executed in GitHub Actions by `.github/workflows/test.yaml`.
+`tests/run.sh` runs all of them in order.
+In GitHub Actions they run through the reusable `.github/workflows/test-environment.yaml`,
+which validates both the script-based and personal-config-repository-based setups.
 
 ### `docs/`
 


### PR DESCRIPTION
Update the `tests/` section in the repository structure guide to match the current CI layout.

- Mention `tests/run.sh` as the entry point that runs the individual tests in order.
- Note that they run through the reusable `test-environment.yaml` workflow, covering both the script-based and personal-config-repository-based setups, instead of the old direct reference to `test.yaml`.
