### PR TITLE
docs: add ubuntu and built-with-nix badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # issl-ubuntu-environment-setup
 
+[![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420.svg?style=flat&logo=ubuntu&logoColor=white)](https://ubuntu.com)
+[![Built with Nix](https://img.shields.io/badge/Built_with_Nix-41439a.svg?style=flat&logo=nixos&logoColor=white)](https://nixos.org)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg?style=flat)](#license)
 [![prek](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/j178/prek/master/docs/assets/badge-v0.json)](https://github.com/j178/prek)
 [![CI](https://github.com/ut-issl/issl-ubuntu-environment-setup/actions/workflows/ci.yaml/badge.svg)](https://github.com/ut-issl/issl-ubuntu-environment-setup/actions/workflows/ci.yaml)


### PR DESCRIPTION
Add Ubuntu and "Built with Nix" badges to the README.
