### PR TITLE
feat(dev): add commitizen, prek, and typos

### DIFF
--- a/docs/91-repository-structure.md
+++ b/docs/91-repository-structure.md
@@ -36,6 +36,7 @@ This directory contains the Home Manager modules that define the shared environm
   - `nix.nix`
   - `shell.nix`
   - `git.nix`
+  - `dev.nix`
   - `cpp.nix`
   - `python.nix`
   - `rust.nix`
@@ -75,6 +76,7 @@ Examples:
 
 - `test-shell.sh` checks shell assets and startup file integration.
 - `test-git.sh` checks Git installation and global include behavior.
+- `test-dev.sh` checks installation of the language-agnostic development tools.
 - `test-python.sh` and `test-rust.sh` check tool installation and shared config wiring.
 - `test-cpp.sh`, `test-vim.sh`, and `test-nix.sh` check the corresponding shared setup.
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,32 +7,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1763992789,
-        "narHash": "sha256-WHkdBlw6oyxXIra/vQPYLtqY+3G8dUVZM8bEXk0t8x4=",
+        "lastModified": 1781981105,
+        "narHash": "sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg+TNl0CjxS3UQJKlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44831a7eaba4360fb81f2acc5ea6de5fde90aaa3",
+        "rev": "7bfff44b465909f69a442701293bc0badcf476dc",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.05",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1782535326,
+        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
   description = "Nix-based ISSL Ubuntu environment setup";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.05";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -53,7 +53,7 @@
             {
               home = {
                 inherit username homeDirectory;
-                stateVersion = "25.05";
+                stateVersion = "26.05";
               };
             }
           ];

--- a/home-modules/dev.nix
+++ b/home-modules/dev.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.commitizen
+    pkgs.prek
+    pkgs.typos
+  ];
+}

--- a/home-modules/main.nix
+++ b/home-modules/main.nix
@@ -7,6 +7,7 @@
     ./nix.nix
     ./shell.nix
     ./git.nix
+    ./dev.nix
     ./cpp.nix
     ./python.nix
     ./rust.nix

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 common_dir="$(cd -- "${COMMON_DIR:-$(dirname -- "${BASH_SOURCE[0]}")/..}" && pwd)"
 export COMMON_DIR="${common_dir}"
 
-for name in nix shell git cpp python rust vim; do
+for name in nix shell git dev cpp python rust vim; do
   printf '\n=== tests/test-%s.sh ===\n' "${name}"
   "${common_dir}/tests/test-${name}.sh"
 done

--- a/tests/test-dev.sh
+++ b/tests/test-dev.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+home_dir="${HOME_DIR:?HOME_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+nix_profile_bin="${home_dir}/.nix-profile/bin"
+
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
+
+assert_commitizen_installation() {
+  test -x "${nix_profile_bin}/cz"
+  test "$(command -v cz)" = "${nix_profile_bin}/cz"
+  cz version
+}
+
+assert_prek_installation() {
+  test -x "${nix_profile_bin}/prek"
+  test "$(command -v prek)" = "${nix_profile_bin}/prek"
+  prek --version
+}
+
+assert_typos_installation() {
+  test -x "${nix_profile_bin}/typos"
+  test "$(command -v typos)" = "${nix_profile_bin}/typos"
+  typos --version
+}
+
+main() {
+  run_assert assert_commitizen_installation
+  run_assert assert_prek_installation
+  run_assert assert_typos_installation
+}
+
+main "$@"


### PR DESCRIPTION
- Add a `dev` Home Manager module for language-agnostic development tooling, providing `commitizen`, `prek`, and `typos`.
- Bump the flake inputs and Home Manager state version from the 25.05 release to 26.05, since `prek` is not packaged in 25.05.
- Add `tests/test-dev.sh` covering the new tools and document the module and test.
