### PR TITLE
refactor: align shell-managed paths with XDG base directories

### DIFF
--- a/assets/python/pythonrc.py
+++ b/assets/python/pythonrc.py
@@ -15,8 +15,8 @@ def _history_path() -> str:
     if histfile:
         return histfile
 
-    python_home = os.path.join(os.path.expanduser("~"), ".python")
-    return os.path.join(python_home, ".python_history")
+    state_home = os.environ.get("XDG_STATE_HOME") or os.path.join(os.path.expanduser("~"), ".local", "state")
+    return os.path.join(state_home, "python", "python_history")
 
 
 def _enable_completion() -> None:

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -5,7 +5,10 @@ if [ "${ISSL_ENV_SH_LOADED:-0}" = "1" ]; then
 fi
 export ISSL_ENV_SH_LOADED=1
 
-export ISSL_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
+export ISSL_CONFIG_HOME="${XDG_CONFIG_HOME}/issl"
 export ISSL_SHELL_HOME="${ISSL_CONFIG_HOME}/shell"
 export ISSL_PYTHON_HOME="${ISSL_CONFIG_HOME}/python"
 export ISSL_RUST_HOME="${ISSL_CONFIG_HOME}/rust"
@@ -30,9 +33,9 @@ prepend_path "${CARGO_HOME}/bin"
 # ===== Python ===== #
 
 if [ -z "${PYTHONSTARTUP:-}" ]; then
-  export PYTHONSTARTUP="${XDG_CONFIG_HOME:-$HOME/.config}/python/pythonrc.py"
+  export PYTHONSTARTUP="${XDG_CONFIG_HOME}/python/pythonrc.py"
 fi
 
 if [ -z "${PYTHONHISTFILE:-}" ]; then
-  export PYTHONHISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/python/python_history"
+  export PYTHONHISTFILE="${XDG_STATE_HOME}/python/python_history"
 fi

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -30,9 +30,9 @@ prepend_path "${CARGO_HOME}/bin"
 # ===== Python ===== #
 
 if [ -z "${PYTHONSTARTUP:-}" ]; then
-  export PYTHONSTARTUP="${HOME}/.python/.pythonrc.py"
+  export PYTHONSTARTUP="${XDG_CONFIG_HOME:-$HOME/.config}/python/pythonrc.py"
 fi
 
 if [ -z "${PYTHONHISTFILE:-}" ]; then
-  export PYTHONHISTFILE="${HOME}/.python/.python_history"
+  export PYTHONHISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/python/python_history"
 fi

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -11,7 +11,13 @@ fi
 
 # ===== History ===== #
 
-export HISTFILE="${ZDOTDIR}/.zsh_history" # Store history under the active ZDOTDIR.
+export HISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/zsh/history" # Persist history under the XDG state directory.
+
+# zsh does not create the history file's parent directory on its own.
+issl_zsh_histfile_dir="${HISTFILE:h}"
+if [ ! -d "${issl_zsh_histfile_dir}" ]; then
+  mkdir -p "${issl_zsh_histfile_dir}" 2>/dev/null || true
+fi
 
 export HISTSIZE=10000 # Keep up to 10000 commands in memory.
 export SAVEHIST=10000 # Persist up to 10000 commands to HISTFILE.

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -250,7 +250,7 @@ resolve_zdotdir_from_zshenv() {
 zshenv_default_block() {
   cat <<'ZSHENV_EOF'
 if [ -z "${ZDOTDIR:-}" ]; then
-  export ZDOTDIR="$HOME/.zsh"
+  export ZDOTDIR="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
 fi
 ZSHENV_EOF
 }
@@ -284,7 +284,7 @@ ensure_zsh_startup_files() {
       "# >>> ISSL zsh env >>>" \
       "# <<< ISSL zsh env <<<" \
       "$(zshenv_default_block)"
-    zdotdir_path="${HOME}/.zsh"
+    zdotdir_path="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
   fi
 
   mkdir -p "${zdotdir_path}"

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -3,7 +3,11 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-issl_config_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl"
+
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
+issl_config_home="${XDG_CONFIG_HOME}/issl"
 shared_nix_config_path="${issl_config_home}/nix/nix.conf"
 shared_bash_profile_path="${issl_config_home}/bash/.bash_profile"
 shared_bashrc_path="${issl_config_home}/bash/.bashrc"
@@ -15,7 +19,7 @@ git_user_name="${GIT_USER_NAME-}"
 git_user_email="${GIT_USER_EMAIL-}"
 issl_enable_zsh="${ISSL_ENABLE_ZSH-}"
 nix_feature_config="experimental-features = nix-command flakes"
-hm_profile_dir="${XDG_STATE_HOME:-$HOME/.local/state}/nix/profiles"
+hm_profile_dir="${XDG_STATE_HOME}/nix/profiles"
 
 # ===== Common ===== #
 
@@ -73,7 +77,7 @@ nix_conf_include_block() {
 }
 
 ensure_nix_conf_include() {
-  local nix_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/nix"
+  local nix_config_dir="${XDG_CONFIG_HOME}/nix"
   local nix_config_path="${nix_config_dir}/nix.conf"
 
   mkdir -p "${nix_config_dir}"
@@ -233,7 +237,7 @@ resolve_zdotdir_from_zshenv() {
   resolved_value="$(
     env -i \
       HOME="${HOME}" \
-      XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}" \
+      XDG_CONFIG_HOME="${XDG_CONFIG_HOME}" \
       ZDOTDIR=""
     # shellcheck disable=SC2016
     "${zsh_bin}" -c '
@@ -284,7 +288,7 @@ ensure_zsh_startup_files() {
       "# >>> ISSL zsh env >>>" \
       "# <<< ISSL zsh env <<<" \
       "$(zshenv_default_block)"
-    zdotdir_path="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
+    zdotdir_path="${XDG_CONFIG_HOME}/zsh"
   fi
 
   mkdir -p "${zdotdir_path}"
@@ -457,7 +461,7 @@ PYTHON_EOF
 
 ensure_python_startup_file() {
   prepend_block_once \
-    "${XDG_CONFIG_HOME:-$HOME/.config}/python/pythonrc.py" \
+    "${XDG_CONFIG_HOME}/python/pythonrc.py" \
     "# >>> ISSL python startup >>>" \
     "# <<< ISSL python startup <<<" \
     "$(pythonrc_block)"

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -457,7 +457,7 @@ PYTHON_EOF
 
 ensure_python_startup_file() {
   prepend_block_once \
-    "${HOME}/.python/.pythonrc.py" \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/python/pythonrc.py" \
     "# >>> ISSL python startup >>>" \
     "# <<< ISSL python startup <<<" \
     "$(pythonrc_block)"

--- a/tests/test-python.sh
+++ b/tests/test-python.sh
@@ -5,7 +5,7 @@ home_dir="${HOME_DIR:?HOME_DIR is required}"
 config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
-pythonrc_path="${home_dir}/.python/.pythonrc.py"
+pythonrc_path="${config_dir}/python/pythonrc.py"
 issl_python_home="${config_dir}/issl/python"
 issl_pythonrc_path="${issl_python_home}/pythonrc.py"
 

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -32,8 +32,8 @@ test "${ISSL_CONFIG_HOME}" = "${XDG_CONFIG_HOME}/issl"
 test "${ISSL_PYTHON_HOME}" = "${XDG_CONFIG_HOME}/issl/python"
 test "${ISSL_RUST_HOME}" = "${XDG_CONFIG_HOME}/issl/rust"
 test "${CARGO_HOME}" = "${HOME}/.cargo"
-test "${PYTHONSTARTUP}" = "${HOME}/.python/.pythonrc.py"
-test "${PYTHONHISTFILE}" = "${HOME}/.python/.python_history"
+test "${PYTHONSTARTUP}" = "${XDG_CONFIG_HOME}/python/pythonrc.py"
+test "${PYTHONHISTFILE}" = "${XDG_STATE_HOME:-$HOME/.local/state}/python/python_history"
 EOF
 }
 

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -6,7 +6,7 @@ config_dir="${CONFIG_DIR:?CONFIG_DIR is required}"
 common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 nix_profile_bin="${home_dir}/.nix-profile/bin"
 nix_profile_share="${home_dir}/.nix-profile/share"
-default_zdotdir="${home_dir}/.zsh"
+default_zdotdir="${config_dir}/zsh"
 issl_enable_zsh="${ISSL_ENABLE_ZSH:?ISSL_ENABLE_ZSH is required}"
 
 # shellcheck source=tests/lib.sh


### PR DESCRIPTION
Consolidate shell-managed paths onto the XDG base directory layout, keeping config and state cleanly separated.

- Move the default `ZDOTDIR` to `$XDG_CONFIG_HOME/zsh` in the script-based setup, and update the shell test expectations to match.
- Move the interactive Python startup to `$XDG_CONFIG_HOME/python` and its history to `$XDG_STATE_HOME/python`.
- Move the zsh history file to `$XDG_STATE_HOME/zsh`, creating its parent directory since zsh does not.
- Normalize `XDG_CONFIG_HOME` / `XDG_STATE_HOME` once at the top of `env.sh` and `apply.sh` instead of repeating the `${XDG_*:-default}` fallback at every use. The fallback is kept where it is the first code to run (the `.zshenv` block written for the user).
