### PR TITLE
ci: deny default token permissions in bump-version and sync-labels

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -14,6 +14,8 @@ on:
           - minor
           - patch
 
+permissions: {}
+
 jobs:
 
   bump-version:

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/sync-labels.yaml'
       - '.github/labels/label-definition.yaml'
 
+permissions: {}
+
 jobs:
 
   sync-labels:


### PR DESCRIPTION
Both `bump-version.yaml` and `sync-labels.yaml` only granted permissions at the job level, leaving the workflow-level default token permissions in place. Set an empty `permissions: {}` block at the top level, matching `manage-pull-requests.yaml`. `test.yaml` and `test-environment.yaml` already declare top-level permissions, so they need no change.
