### PR TITLE
ci: set a 10-minute timeout on every job

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -21,6 +21,7 @@ jobs:
   bump-version:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
   determine-changes:
     name: Determine changed files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       github_actions: ${{ steps.changed-files.outputs.github_actions_any_changed }}
       github_actions_ci: ${{ steps.changed-files.outputs.github_actions_ci_any_changed }}
@@ -85,6 +86,7 @@ jobs:
     needs: determine-changes
     if: ${{ needs.determine-changes.outputs.github_actions == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -137,6 +139,7 @@ jobs:
       ${{ needs.determine-changes.outputs.renovate_config == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -163,6 +166,7 @@ jobs:
       ${{ needs.determine-changes.outputs.nix == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -219,6 +223,7 @@ jobs:
       ${{ needs.determine-changes.outputs.sh_bash == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: write
@@ -290,6 +295,7 @@ jobs:
       ${{ needs.determine-changes.outputs.zsh == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -343,6 +349,7 @@ jobs:
       ${{ needs.determine-changes.outputs.md == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -390,6 +397,7 @@ jobs:
       ${{ needs.determine-changes.outputs.json5 == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -428,6 +436,7 @@ jobs:
       ${{ needs.determine-changes.outputs.toml == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -503,6 +512,7 @@ jobs:
       ${{ needs.determine-changes.outputs.yaml == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -539,6 +549,7 @@ jobs:
       ${{ needs.determine-changes.outputs.python == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: write
@@ -606,6 +617,7 @@ jobs:
   check-prek:
     name: Check prek
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout the main repository
@@ -627,6 +639,7 @@ jobs:
   check-typos:
     name: Check typos
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: write
@@ -654,6 +667,7 @@ jobs:
   lint-commit-messages:
     name: Lint commit messages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout the main repository

--- a/.github/workflows/manage-pull-requests.yaml
+++ b/.github/workflows/manage-pull-requests.yaml
@@ -15,6 +15,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
@@ -28,6 +29,7 @@ jobs:
     name: Lint PR title
     if: github.event.action != 'edited' || github.event.changes.title != null
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Set up Commitizen

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -21,6 +21,7 @@ jobs:
   sync-labels:
     name: Sync Labels
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/test-environment.yaml
+++ b/.github/workflows/test-environment.yaml
@@ -26,6 +26,10 @@ on:
         required: false
         type: boolean
         default: false
+      timeout-minutes:
+        required: false
+        type: number
+        default: 10
 
 permissions:
   contents: read
@@ -34,7 +38,7 @@ jobs:
   test:
     name: Test (${{ matrix.enable_zsh_name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/test-environment.yaml
+++ b/.github/workflows/test-environment.yaml
@@ -34,6 +34,7 @@ jobs:
   test:
     name: Test (${{ matrix.enable_zsh_name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
Jobs without `timeout-minutes` fall back to the 6-hour default, so a hung runner occupies its slot for hours.

Add a uniform `timeout-minutes: 10` to every job across the workflows. This includes the matrix test job in the reusable `test-environment.yaml`: recent runs finish in at most ~1.6 minutes on cold runners, so 10 minutes leaves ample headroom while capping hangs.

The caller jobs in `test.yaml` use `jobs.<id>.uses`, which does not accept `timeout-minutes`; their limit is enforced by the job inside the called workflow.
