### PR TITLE
fix: run zshenv ZDOTDIR resolution under a clean environment

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -234,13 +234,14 @@ resolve_zdotdir_from_zshenv() {
     return 1
   fi
 
+  # shellcheck disable=SC2016
   resolved_value="$(
     env -i \
       HOME="${HOME}" \
       XDG_CONFIG_HOME="${XDG_CONFIG_HOME}" \
-      ZDOTDIR=""
-    # shellcheck disable=SC2016
-    "${zsh_bin}" -c '
+      ZDOTDIR="" \
+      PATH=/usr/bin:/bin \
+      "${zsh_bin}" -c '
         . "$1"
         if [ -n "${ZDOTDIR:-}" ]; then
           print -r -- "${ZDOTDIR:A}"


### PR DESCRIPTION
- A comment line interrupted the `env -i` invocation in `resolve_zdotdir_from_zshenv`, so `env -i` ran with no command and printed the environment into the command substitution, while zsh ran outside the isolated environment.
- When `~/.zshenv` already defined `ZDOTDIR`, the resulting multi-line value was passed to `mkdir -p`, creating garbage directories and writing the zsh startup files to the wrong place.
- Join the `env -i` and zsh invocation into a single command with proper line continuations, and pass a minimal `PATH` so the sourced zshenv can still invoke external commands.
