### PR TITLE
fix: stop exporting shell rc load guards

### DIFF
--- a/assets/bash/bashrc.bash
+++ b/assets/bash/bashrc.bash
@@ -4,7 +4,7 @@
 if [[ ${ISSL_BASHRC_LOADED:-0} == "1" ]]; then
   return 0
 fi
-export ISSL_BASHRC_LOADED=1
+ISSL_BASHRC_LOADED=1
 
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 

--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -4,7 +4,7 @@
 if [ "${ISSL_RC_SH_LOADED:-0}" = "1" ]; then
   return 0
 fi
-export ISSL_RC_SH_LOADED=1
+ISSL_RC_SH_LOADED=1
 
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 

--- a/assets/zsh/zshrc.zsh
+++ b/assets/zsh/zshrc.zsh
@@ -1,7 +1,7 @@
 if [ "${ISSL_ZSHRC_LOADED:-0}" = "1" ]; then
   return 0
 fi
-export ISSL_ZSHRC_LOADED=1
+ISSL_ZSHRC_LOADED=1
 
 issl_bootstrap_shell_home="${XDG_CONFIG_HOME:-$HOME/.config}/issl/shell"
 


### PR DESCRIPTION
- The rc-level load guards (`ISSL_RC_SH_LOADED`, `ISSL_BASHRC_LOADED`, `ISSL_ZSHRC_LOADED`) were exported, so nested interactive shells (tmux panes, `bash`/`zsh` started from a shell, tool-spawned subshells) inherited them and skipped the rc files entirely, losing aliases, shell functions, options, and completion setup.
- Change the guard assignments to plain (non-exported) shell variables so nested shells re-source the rc files, while same-shell double-sourcing remains guarded.
- `env.sh` keeps its exported guard on purpose: it only sets environment variables, which child shells inherit anyway, so re-sourcing it in nested shells is unnecessary.
