### PR TITLE
fix: pin the default setup.sh clone ref to the release version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,3 +2,8 @@
 current_version = "0.2.7"
 commit = false
 tag = false
+
+[[tool.bumpversion.files]]
+filename = "scripts/setup.sh"
+search = "default_repo_ref=\"v{current_version}\""
+replace = "default_repo_ref=\"v{new_version}\""

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -7,3 +7,8 @@ tag = false
 filename = "scripts/setup.sh"
 search = "default_repo_ref=\"v{current_version}\""
 replace = "default_repo_ref=\"v{new_version}\""
+
+[[tool.bumpversion.files]]
+filename = "docs/12-script-based-setup.md"
+search = "v{current_version}"
+replace = "v{new_version}"

--- a/docs/12-script-based-setup.md
+++ b/docs/12-script-based-setup.md
@@ -10,11 +10,15 @@ Run:
 bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/latest/download/setup.sh)
 ```
 
-To pin setup to a fixed release, replace `latest` with a tag such as `v0.1.2`:
+To pin setup to a fixed release, replace `latest` with a tag such as `v0.2.7`:
 
 ```bash
-bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/download/v0.1.2/setup.sh)
+bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/download/v0.2.7/setup.sh)
 ```
+
+Each release's `setup.sh` defaults to installing that same release,
+so pinning the download tag also pins the installed environment.
+Set the `REPO_REF` (and `REPO_URL`) environment variables to override this default, e.g. `REPO_REF=main` for development.
 
 To override setup variables, set them before running the command. For example:
 

--- a/docs/12-script-based-setup.md
+++ b/docs/12-script-based-setup.md
@@ -18,9 +18,9 @@ bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/relea
 
 Each release's `setup.sh` defaults to installing that same release,
 so pinning the download tag also pins the installed environment.
-Set the `REPO_REF` (and `REPO_URL`) environment variables to override this default, e.g. `REPO_REF=main` for development.
 
-To override setup variables, set them before running the command. For example:
+To override setup variables, set environment variables before running the command.
+For example, set `REPO_REF=main` for development, or set `INSTALL_DIR` to choose another install location:
 
 ```bash
 INSTALL_DIR="$HOME/.issl-ubuntu-environment-setup" \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,8 +2,9 @@
 
 set -euo pipefail
 
+default_repo_ref="v0.2.7"
 repo_url="${REPO_URL:-https://github.com/ut-issl/issl-ubuntu-environment-setup.git}"
-repo_ref="${REPO_REF:-main}"
+repo_ref="${REPO_REF:-${default_repo_ref}}"
 data_root="${XDG_DATA_HOME:-$HOME/.local/share}"
 install_dir="${INSTALL_DIR:-$data_root/issl/ubuntu-environment-setup}"
 ssh_dir="${HOME}/.ssh"


### PR DESCRIPTION
- Released copies of `setup.sh` cloned `main` regardless of which release they were downloaded from, so pinning the download tag did not pin the installed environment.
- The default clone ref is now the current version tag, kept in sync by bump-my-version on every release.
- The `REPO_REF` environment variable still overrides the default (e.g. `REPO_REF=main` for development).
- The script-based setup docs now describe the new pinning behavior.
