### PR TITLE
fix: start nix-daemon in the background in no-systemd environments

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -146,13 +146,13 @@ start_nix_daemon_without_systemd() {
   fi
 
   for _ in {1..10}; do
-    if pgrep -x nix-daemon >/dev/null 2>&1; then
+    if nix --extra-experimental-features "nix-command flakes" store info >/dev/null 2>&1; then
       return
     fi
     sleep 1
   done
 
-  echo "warning: attempted to start nix-daemon, but it is not running yet. Nix commands may fail." >&2
+  echo "warning: attempted to start nix-daemon, but it is not responding yet. Nix commands may fail." >&2
 }
 
 # ===== Bash ===== #

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -128,21 +128,16 @@ start_nix_daemon_without_systemd() {
   fi
 
   if [ "$(id -u)" = "0" ]; then
-    if ! "${nix_daemon_path}" --daemon >/dev/null 2>&1; then
-      echo "warning: failed to start nix-daemon as root. Nix commands may fail." >&2
-      return
-    fi
+    setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
   elif command -v sudo >/dev/null 2>&1; then
     if [ -t 0 ]; then
-      if ! sudo "${nix_daemon_path}" --daemon >/dev/null 2>&1; then
-        echo "warning: failed to start nix-daemon via sudo. Nix commands may fail." >&2
+      if ! sudo -v; then
+        echo "warning: failed to authenticate via sudo. Nix commands may fail." >&2
         return
       fi
+      sudo setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
     elif sudo -n true >/dev/null 2>&1; then
-      if ! sudo "${nix_daemon_path}" --daemon >/dev/null 2>&1; then
-        echo "warning: failed to start nix-daemon via passwordless sudo. Nix commands may fail." >&2
-        return
-      fi
+      sudo -n setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
     else
       echo "warning: cannot start nix-daemon automatically (sudo requires a password in non-interactive mode)." >&2
       return

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -135,13 +135,11 @@ start_nix_daemon_without_systemd() {
         echo "warning: failed to authenticate via sudo. Nix commands may fail." >&2
         return
       fi
-      sudo -n setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
-    elif sudo -n true >/dev/null 2>&1; then
-      sudo -n setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
-    else
+    elif ! sudo -n true >/dev/null 2>&1; then
       echo "warning: cannot start nix-daemon automatically (sudo requires a password in non-interactive mode)." >&2
       return
     fi
+    sudo -n setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
   else
     echo "warning: cannot start nix-daemon automatically (sudo is unavailable in a no-systemd environment)." >&2
     return

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -135,7 +135,7 @@ start_nix_daemon_without_systemd() {
         echo "warning: failed to authenticate via sudo. Nix commands may fail." >&2
         return
       fi
-      sudo setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
+      sudo -n setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
     elif sudo -n true >/dev/null 2>&1; then
       sudo -n setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
     else


### PR DESCRIPTION
- `nix-daemon --daemon` runs its accept loop in the foreground and does not fork, so launching it under `if ! ...` made `apply.sh` block indefinitely whenever the daemon started successfully in no-systemd environments.
- Launch the daemon detached in the background with `setsid` instead, in all three launch paths (root, interactive sudo, passwordless sudo).
- In interactive runs, validate sudo credentials up front with `sudo -v` so the password prompt is not swallowed by backgrounding.
- Rely on the existing `pgrep` wait loop as the single success check and drop the per-branch failure warnings that no longer apply to a backgrounded launch.
