### PR TITLE
fix(rust): preserve the user-selected default rustup toolchain

### DIFF
--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -8,12 +8,9 @@
 
   xdg.configFile."issl/rust/config.toml".source = ../assets/rust/config.toml;
 
-  home.activation.rustupDefaultStable = lib.hm.dag.entryAfter [ "installPackages" ] ''
+  home.activation.rustupEnsureDefaultToolchain = lib.hm.dag.entryAfter [ "installPackages" ] ''
     rustup=${pkgs.rustup}/bin/rustup
-    if ! "$rustup" show active-toolchain >/dev/null 2>&1; then
-      run "$rustup" toolchain install stable
-    fi
-    if ! "$rustup" show active-toolchain 2>/dev/null | grep -Eq '^stable(-|$)'; then
+    if ! "$rustup" default >/dev/null 2>&1; then
       run "$rustup" default stable
     fi
   '';


### PR DESCRIPTION
The rustup activation forced `rustup default stable` whenever the active toolchain was not stable, silently reverting a user's deliberate choice (e.g. `rustup default nightly`) on every `home-manager switch`.

- Set stable only when no default toolchain is configured, checking `rustup default` (which ignores directory overrides) instead of the active toolchain.
- `rustup default stable` installs the toolchain when missing, so a fresh environment is still covered in a single step.
- Rename the activation entry to `rustupEnsureDefaultToolchain` to match the new semantics.

Closes #333
