### PR TITLE
fix(setup): match GitHub SSH Host keyword case-insensitively

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -155,7 +155,7 @@ ensure_github_ssh_config() {
   ensure_ssh_directory
 
   if [ -f "${ssh_config_path}" ] &&
-    grep -Eq '^[[:space:]]*Host[[:space:]]+github\.com([[:space:]]|$)' "${ssh_config_path}"; then
+    grep -Eiq '^[[:space:]]*Host[[:space:]]+github\.com([[:space:]]|$)' "${ssh_config_path}"; then
     return
   fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -155,7 +155,7 @@ ensure_github_ssh_config() {
   ensure_ssh_directory
 
   if [ -f "${ssh_config_path}" ] &&
-    grep -Eiq '^[[:space:]]*Host[[:space:]]+github\.com([[:space:]]|$)' "${ssh_config_path}"; then
+    grep -Eq '^[[:space:]]*[Hh][Oo][Ss][Tt][[:space:]]+github\.com([[:space:]]|$)' "${ssh_config_path}"; then
     return
   fi
 


### PR DESCRIPTION
`ensure_github_ssh_config` detected an existing GitHub host block by matching the `Host` keyword case-sensitively. Since SSH config keywords are case-insensitive, an existing lowercase `host github.com` block was not detected, causing a duplicate block to be appended to `~/.ssh/config`.

Add the `-i` flag to `grep` so the keyword is matched case-insensitively.

Closes #338
