### PR TITLE
fix(shell): make Nix tools and session vars self-contained in env.sh

### DIFF
--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -29,6 +29,16 @@ prepend_path() {
 
 prepend_path "$HOME/.local/bin"
 prepend_path "${CARGO_HOME}/bin"
+prepend_path "${ISSL_NIX_PROFILE_PATH}/bin"
+prepend_path "/nix/var/nix/profiles/default/bin"
+if [ -n "${USER:-}" ]; then
+  prepend_path "/nix/var/nix/profiles/per-user/${USER}/profile/bin"
+fi
+
+if [ -r "${ISSL_NIX_PROFILE_PATH}/etc/profile.d/hm-session-vars.sh" ]; then
+  # shellcheck source=/dev/null
+  . "${ISSL_NIX_PROFILE_PATH}/etc/profile.d/hm-session-vars.sh"
+fi
 
 # ===== Python ===== #
 

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -43,18 +43,19 @@ assert_bash_startup_files() {
 }
 
 assert_bash_startup_is_loaded() {
-  # Drive a login + interactive bash and confirm the shared startup files ran,
-  # observed through their load guards.
+  # Drive a login + interactive bash and confirm the shared startup files ran (observed through their load guards)
+  # and that env.sh put the Nix profile bin on PATH by itself, without the Nix installer's system-wide shell hooks.
   # shellcheck disable=SC2016  # ${...} inside the single-quoted -c argument expand in the subshell.
   env -i \
     HOME="${home_dir}" \
     XDG_CONFIG_HOME="${config_dir}" \
-    PATH="${nix_profile_bin}:/usr/bin:/bin" \
+    PATH="/usr/bin:/bin" \
     TERM=dumb \
     bash -lic '
       ok=1
       [ "${ISSL_ENV_SH_LOADED:-0}" = "1" ] || { echo "login shell did not load the shared env.sh" >&2; ok=0; }
       [ "${ISSL_BASHRC_LOADED:-0}" = "1" ] || { echo "interactive shell did not load the shared bashrc" >&2; ok=0; }
+      [ "$(command -v colordiff)" = "${HOME}/.nix-profile/bin/colordiff" ] || { echo "env.sh did not add the Nix profile bin to PATH" >&2; ok=0; }
       [ "${ok}" = "1" ]
     '
 }
@@ -93,12 +94,13 @@ assert_zsh_startup_is_loaded() {
   env -i \
     HOME="${home_dir}" \
     XDG_CONFIG_HOME="${config_dir}" \
-    PATH="${nix_profile_bin}:/usr/bin:/bin" \
+    PATH="/usr/bin:/bin" \
     TERM=dumb \
-    zsh -lic '
+    "${nix_profile_bin}/zsh" -lic '
       ok=1
       [ "${ISSL_ENV_SH_LOADED:-0}" = "1" ] || { echo "login shell did not load the shared env.sh" >&2; ok=0; }
       [ "${ISSL_ZSHRC_LOADED:-0}" = "1" ] || { echo "interactive shell did not load the shared zshrc" >&2; ok=0; }
+      [ "$(command -v colordiff)" = "${HOME}/.nix-profile/bin/colordiff" ] || { echo "env.sh did not add the Nix profile bin to PATH" >&2; ok=0; }
       [ "${ok}" = "1" ]
     '
 }


### PR DESCRIPTION
The script-based setup applies a Home Manager configuration that does not enable `programs.bash`/`programs.zsh`, so the shared shell assets never add the Nix profile bin directories to `PATH` nor source `hm-session-vars.sh`.
Nix tool availability then depends on the Nix installer's edits to `/etc/bash.bashrc` and `/etc/zshrc`, which non-login, non-interactive shells such as `ssh host <command>` do not read, and any `home.sessionVariables` stay unset.

- Prepend the Nix profile bin directories in `env.sh`, mirroring `setup.sh`'s `refresh_path_for_nix`, and source `hm-session-vars.sh` when present (it guards against double-sourcing).
- Strengthen the shell startup tests to stop pre-seeding the Nix profile bin into `PATH` and instead assert that `env.sh` makes a Nix-provided tool reachable on its own.

Closes #336
