### PR TITLE
test(ci): enable config-repository-based setup test

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -145,6 +145,19 @@
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'j178/prek',
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.github/workflows/test\\.ya?ml$/',
+      ],
+      matchStrings: [
+        'user-ref: (?<currentDigest>[a-f0-9]{40}) # (?<currentValue>\\S+)',
+      ],
+      autoReplaceStringTemplate: 'user-ref: {{{newDigest}}} # {{{currentValue}}}',
+      datasourceTemplate: 'git-refs',
+      depNameTemplate: 'ut-issl/personal-nix-config-template',
+      packageNameTemplate: 'https://github.com/ut-issl/personal-nix-config-template',
+    },
   ],
   packageRules: [
     {
@@ -264,6 +277,12 @@
       ],
       matchUpdateTypes: [
         'patch',
+      ],
+      automerge: true,
+    },
+    {
+      matchDepNames: [
+        'ut-issl/personal-nix-config-template',
       ],
       automerge: true,
     },

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,5 +49,5 @@ jobs:
       common-repository: ${{ github.repository }}
       common-ref: ${{ github.sha }}
       user-repository: ut-issl/personal-nix-config-template
-      user-ref: c102a1225713bea36ef3943b99f47fe2fbae9965 # main
+      user-ref: 987415354bc6d11cafeac0b5e9d64f6e45a49d00 # main
       override-issl-input: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,13 +41,13 @@ jobs:
       common-repository: ${{ github.repository }}
       common-ref: ${{ github.sha }}
 
-  # user-repo:
-  #   name: Test config-repository-based setup
-  #   uses: ./.github/workflows/test-environment.yaml
-  #   with:
-  #     setup-mode: repository-based
-  #     common-repository: ${{ github.repository }}
-  #     common-ref: ${{ github.sha }}
-  #     user-repository: ut-issl/personal-nix-config-template
-  #     user-ref: main
-  #     override-issl-input: true
+  user-repo:
+    name: Test config-repository-based setup
+    uses: ./.github/workflows/test-environment.yaml
+    with:
+      setup-mode: repository-based
+      common-repository: ${{ github.repository }}
+      common-ref: ${{ github.sha }}
+      user-repository: ut-issl/personal-nix-config-template
+      user-ref: main
+      override-issl-input: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,5 +49,5 @@ jobs:
       common-repository: ${{ github.repository }}
       common-ref: ${{ github.sha }}
       user-repository: ut-issl/personal-nix-config-template
-      user-ref: main
+      user-ref: c102a1225713bea36ef3943b99f47fe2fbae9965 # main
       override-issl-input: true


### PR DESCRIPTION
The user config template repository is now public, so the previously disabled config-repository-based setup test job can now run in CI.

- Uncomment the `user-repo` job in `.github/workflows/test.yaml`.
- Pin `user-ref` to a reviewed commit SHA so unrelated changes on the template repository cannot break this repository's CI, and track it with a Renovate custom manager (auto-updates are gated by this same test).
