### PR TITLE
ci(test): rename test jobs to match setup mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ permissions:
   contents: read
 
 jobs:
-  apply:
+  script-based:
     name: Test script-based setup
     uses: ./.github/workflows/test-environment.yaml
     with:
@@ -41,7 +41,7 @@ jobs:
       common-repository: ${{ github.repository }}
       common-ref: ${{ github.sha }}
 
-  user-repo:
+  repository-based:
     name: Test config-repository-based setup
     uses: ./.github/workflows/test-environment.yaml
     with:


### PR DESCRIPTION
Rename the `apply` and `user-repo` jobs to `script-based` and `repository-based` so the job keys align with the `setup-mode` input values they pass.
