### PR TITLE
ci(bump-version): create version bump PR with a GitHub App token

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -27,9 +27,18 @@ jobs:
       pull-requests: write
 
     steps:
-      - id: bump-version
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Bump version
+        id: bump-version
         uses: conjikidow/bump-version-action@f3a9763279155551196c80dab1c1891cbc51df9f # v4.0.2
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           label-major: 'update::major'
           label-minor: 'update::minor'
           label-patch: 'update::patch'


### PR DESCRIPTION
Generate a GitHub App token and pass it to the bump-version action so the version bump pull request is opened by the App instead of the default `GITHUB_TOKEN`.

Pull requests created with `GITHUB_TOKEN` have their `pull_request` workflow runs held in an approval-required state, so CI did not run automatically on the bump PR. Using an App token lets those workflows run without the manual approval prompt.

Requires `vars.GH_APP_CLIENT_ID` and `secrets.GH_APP_PRIVATE_KEY` to be configured, with the App granted `contents: write` and `pull-requests: write`.
