### PR TITLE
chore(renovate): drop cooldown for personal-nix-config-template digest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -284,6 +284,7 @@
       matchDepNames: [
         'ut-issl/personal-nix-config-template',
       ],
+      minimumReleaseAge: '0 days',
       automerge: true,
     },
   ],


### PR DESCRIPTION
The user config template used in the test workflow is tracked as a moving branch digest via the `git-refs` datasource.
For digest updates Renovate uses the commit timestamp, so the top-level `minimumReleaseAge: '3 days'` applied to these bumps and held them behind a pending `renovate/stability-days` check.

Set `minimumReleaseAge: '0 days'` on `ut-issl/personal-nix-config-template` so the digest updates merge without delay, matching the cooldown-free setup already used for the reverse reference.
