### PR TITLE
feat(ci): pin and matrix runner OS in environment tests

### DIFF
--- a/.github/workflows/test-environment.yaml
+++ b/.github/workflows/test-environment.yaml
@@ -6,6 +6,10 @@ on:
       setup-mode:
         required: true
         type: string
+      os:
+        required: false
+        type: string
+        default: ubuntu-latest
       common-repository:
         required: false
         type: string
@@ -37,7 +41,7 @@ permissions:
 jobs:
   test:
     name: Test (${{ matrix.enable_zsh_name }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,17 +35,33 @@ permissions:
 jobs:
   script-based:
     name: Test script-based setup
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-26.04
     uses: ./.github/workflows/test-environment.yaml
     with:
       setup-mode: script-based
+      os: ${{ matrix.os }}
       common-repository: ${{ github.repository }}
       common-ref: ${{ github.sha }}
 
   repository-based:
     name: Test config-repository-based setup
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-26.04
     uses: ./.github/workflows/test-environment.yaml
     with:
       setup-mode: repository-based
+      os: ${{ matrix.os }}
       common-repository: ${{ github.repository }}
       common-ref: ${{ github.sha }}
       user-repository: ut-issl/personal-nix-config-template

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # issl-ubuntu-environment-setup
 
-[![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420.svg?style=flat&logo=ubuntu&logoColor=white)](https://ubuntu.com)
+[![Ubuntu](https://img.shields.io/badge/Ubuntu-22.04%20%7C%2024.04%20%7C%2026.04-E95420.svg?style=flat&logo=ubuntu&logoColor=white)](https://ubuntu.com)
 [![Built with Nix](https://img.shields.io/badge/Built_with_Nix-41439a.svg?style=flat&logo=nixos&logoColor=white)](https://nixos.org)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg?style=flat)](#license)
 [![prek](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/j178/prek/master/docs/assets/badge-v0.json)](https://github.com/j178/prek)


### PR DESCRIPTION
The environment tests ran on `ubuntu-latest`, leaving the tested Ubuntu version implicit and tied to whatever GitHub's latest label points to.
Since this project sets up Ubuntu environments, the version under test is significant and should be explicit.

- Add an `os` input to the reusable `test-environment.yaml` and use it as `runs-on` (defaults to `ubuntu-latest`, so existing callers keep working).
- Drive it from a caller-side matrix of `ubuntu-22.04`, `ubuntu-24.04`, and `ubuntu-26.04` in `test.yaml`, so each caller declares its own list and can adjust it independently.
- Passing full runner labels keeps the OS visible in job names and leaves room for callers to extend to non-Ubuntu runners.

Note: `ubuntu-26.04` is currently a preview runner image (not yet GA), so those jobs may be unstable until it reaches GA. `fail-fast: false` keeps the other versions running.
