### PR TITLE
feat: install nodejs

### DIFF
--- a/docs/13-package-management-practices.md
+++ b/docs/13-package-management-practices.md
@@ -29,6 +29,12 @@ Use project-local package managers for dependencies that belong to a specific re
 - `uv` is available through this environment.
 - Manage project-local Python environments with `uv`, and define them in `pyproject.toml` in each repository.
 
+### Node.js
+
+- `node`, `npm`, and `npx` are available through this environment.
+- Manage project-local JavaScript dependencies with `npm`, and define them with `package.json` in each repository.
+- Install globally available user-environment tools with Nix/Home Manager instead of `npm install -g`.
+
 ## 3. System-Level Packages
 
 Use `apt` only when system-level integration is required, such as services, drivers, or low-level OS packages.

--- a/home-modules/main.nix
+++ b/home-modules/main.nix
@@ -9,6 +9,7 @@
     ./git.nix
     ./dev.nix
     ./cpp.nix
+    ./node.nix
     ./python.nix
     ./rust.nix
     ./vim.nix

--- a/home-modules/node.nix
+++ b/home-modules/node.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [ pkgs.nodejs ];
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 common_dir="$(cd -- "${COMMON_DIR:-$(dirname -- "${BASH_SOURCE[0]}")/..}" && pwd)"
 export COMMON_DIR="${common_dir}"
 
-for name in nix shell git dev cpp python rust vim; do
+for name in nix shell git dev cpp node python rust vim; do
   printf '\n=== tests/test-%s.sh ===\n' "${name}"
   "${common_dir}/tests/test-${name}.sh"
 done

--- a/tests/test-node.sh
+++ b/tests/test-node.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+home_dir="${HOME_DIR:?HOME_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+nix_profile_bin="${home_dir}/.nix-profile/bin"
+
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
+
+assert_node_installation() {
+  test -x "${nix_profile_bin}/node"
+  test "$(command -v node)" = "${nix_profile_bin}/node"
+  node --version
+}
+
+assert_npm_installation() {
+  test -x "${nix_profile_bin}/npm"
+  test "$(command -v npm)" = "${nix_profile_bin}/npm"
+  npm --version
+}
+
+assert_npx_installation() {
+  test -x "${nix_profile_bin}/npx"
+  test "$(command -v npx)" = "${nix_profile_bin}/npx"
+  npx --version
+}
+
+main() {
+  run_assert assert_node_installation
+  run_assert assert_npm_installation
+  run_assert assert_npx_installation
+}
+
+main "$@"


### PR DESCRIPTION
- Add Node.js to the shared Home Manager environment so `node`, `npm`, and `npx` are available.
- Add an environment test for the Node.js tools.
- Document project-local Node.js package management guidance.

Closes #367