### PR TITLE
feat: install github cli

### DIFF
--- a/home-modules/git.nix
+++ b/home-modules/git.nix
@@ -1,7 +1,10 @@
 { pkgs, ... }:
 
 {
-  home.packages = [ pkgs.git ];
+  home.packages = [
+    pkgs.git
+    pkgs.gh
+  ];
 
   xdg.configFile."issl/git/.gitconfig".source = ../assets/git/.gitconfig;
 }

--- a/tests/test-git.sh
+++ b/tests/test-git.sh
@@ -15,6 +15,12 @@ assert_git_installation() {
   git --version
 }
 
+assert_gh_installation() {
+  test -x "${nix_profile_bin}/gh"
+  test "$(command -v gh)" = "${nix_profile_bin}/gh"
+  gh --version
+}
+
 assert_shared_git_config() {
   cmp "${common_dir}/assets/git/.gitconfig" "${config_dir}/issl/git/.gitconfig"
 }
@@ -48,6 +54,7 @@ assert_git_identity() {
 
 main() {
   run_assert assert_git_installation
+  run_assert assert_gh_installation
   run_assert assert_shared_git_config
   run_assert assert_global_git_include
   run_assert assert_git_identity


### PR DESCRIPTION
- Add GitHub CLI to the Git module.
- Extend the Git environment test to verify `gh` is installed.

Closes #365