### PR TITLE
feat: add Docker CLI tools

### DIFF
--- a/home-modules/docker.nix
+++ b/home-modules/docker.nix
@@ -1,9 +1,20 @@
 { pkgs, ... }:
 
+let
+  dockerCompose = pkgs.symlinkJoin {
+    name = "docker-compose";
+    paths = [ pkgs.docker-compose ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram "$out/bin/docker-compose" \
+        --prefix DOCKER_CLI_PLUGIN_DIRS : "${pkgs.docker-compose}/libexec/docker/cli-plugins:${pkgs.docker-buildx}/libexec/docker/cli-plugins"
+    '';
+  };
+in
 {
   home.packages = [
     pkgs.docker-client
-    pkgs.docker-compose
     pkgs.docker-buildx
+    dockerCompose
   ];
 }

--- a/home-modules/docker.nix
+++ b/home-modules/docker.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.docker-client
+    pkgs.docker-compose
+    pkgs.docker-buildx
+  ];
+}

--- a/home-modules/main.nix
+++ b/home-modules/main.nix
@@ -9,6 +9,7 @@
     ./git.nix
     ./dev.nix
     ./codex.nix
+    ./docker.nix
     ./cpp.nix
     ./node.nix
     ./python.nix

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 common_dir="$(cd -- "${COMMON_DIR:-$(dirname -- "${BASH_SOURCE[0]}")/..}" && pwd)"
 export COMMON_DIR="${common_dir}"
 
-for name in nix shell git dev codex cpp node python rust typst vim; do
+for name in nix shell git dev codex docker cpp node python rust typst vim; do
   printf '\n=== tests/test-%s.sh ===\n' "${name}"
   "${common_dir}/tests/test-${name}.sh"
 done

--- a/tests/test-docker.sh
+++ b/tests/test-docker.sh
@@ -20,6 +20,11 @@ assert_docker_compose_installation() {
   docker-compose version
 }
 
+assert_docker_compose_plugin_dirs_wrapper() {
+  grep -Fq "DOCKER_CLI_PLUGIN_DIRS" "${nix_profile_bin}/docker-compose"
+  grep -Fq "docker-buildx" "${nix_profile_bin}/docker-compose"
+}
+
 assert_docker_buildx_installation() {
   test -x "${nix_profile_bin}/docker-buildx"
   test "$(command -v docker-buildx)" = "${nix_profile_bin}/docker-buildx"
@@ -29,6 +34,7 @@ assert_docker_buildx_installation() {
 main() {
   run_assert assert_docker_client_installation
   run_assert assert_docker_compose_installation
+  run_assert assert_docker_compose_plugin_dirs_wrapper
   run_assert assert_docker_buildx_installation
 }
 

--- a/tests/test-docker.sh
+++ b/tests/test-docker.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+home_dir="${HOME_DIR:?HOME_DIR is required}"
+common_dir="${COMMON_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+nix_profile_bin="${home_dir}/.nix-profile/bin"
+
+# shellcheck source=tests/lib.sh
+source "${common_dir}/tests/lib.sh"
+
+assert_docker_client_installation() {
+  test -x "${nix_profile_bin}/docker"
+  test "$(command -v docker)" = "${nix_profile_bin}/docker"
+  docker --version
+}
+
+assert_docker_compose_installation() {
+  test -x "${nix_profile_bin}/docker-compose"
+  test "$(command -v docker-compose)" = "${nix_profile_bin}/docker-compose"
+  docker-compose version
+}
+
+assert_docker_buildx_installation() {
+  test -x "${nix_profile_bin}/docker-buildx"
+  test "$(command -v docker-buildx)" = "${nix_profile_bin}/docker-buildx"
+  docker-buildx version
+}
+
+main() {
+  run_assert assert_docker_client_installation
+  run_assert assert_docker_compose_installation
+  run_assert assert_docker_buildx_installation
+}
+
+main "$@"


### PR DESCRIPTION
- Add a Docker Home Manager module with the Docker client, Compose plugin, and Buildx plugin.
- Include the Docker module in the shared configuration.
- Add Docker CLI installation checks to the test suite.

Refs #366