### PR TITLE
refactor: split host bootstrap setup

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -50,6 +50,7 @@ jobs:
         if: steps.bump-version.outputs.version-bumped == 'true'
         run: |
           mkdir -p release-assets
+          cp scripts/bootstrap-host.sh release-assets/bootstrap-host.sh
           cp scripts/setup.sh release-assets/setup.sh
 
       - name: Create GitHub release
@@ -58,6 +59,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: v${{ steps.bump-version.outputs.new-version }}
         run: |
-          gh release create "${RELEASE_TAG}" release-assets/setup.sh \
+          gh release create "${RELEASE_TAG}" release-assets/bootstrap-host.sh release-assets/setup.sh \
             --title "${RELEASE_TAG}" \
             --generate-notes

--- a/docs/12-script-based-setup.md
+++ b/docs/12-script-based-setup.md
@@ -29,6 +29,19 @@ bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/relea
 
 After setup, open a new shell.
 
+### Optional Docker Engine Setup
+
+The shared Home Manager configuration installs the Docker CLI tools.
+Interactive setup prompts to install the host Docker Engine with yes as the default answer.
+Non-interactive setup skips Docker Engine unless you opt in explicitly:
+
+```bash
+ISSL_INSTALL_DOCKER=yes \
+bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/latest/download/setup.sh)
+```
+
+Set `ISSL_INSTALL_DOCKER=no` to skip the prompt explicitly.
+
 ## If You Need Additional Tools or Settings
 
 This workflow assumes the shared setup is usually sufficient.

--- a/docs/12-script-based-setup.md
+++ b/docs/12-script-based-setup.md
@@ -29,6 +29,17 @@ bash <(curl -fsSL https://github.com/ut-issl/issl-ubuntu-environment-setup/relea
 
 After setup, open a new shell.
 
+### Repository Overrides
+
+Set `REPO_URL` and `REPO_REF` to install from another GitHub repository or ref.
+For streamed setup, bootstrap script selection has the following limits:
+
+- HTTPS public forks and mirrors are supported.
+- SSH private repositories can be used as the install target,
+  but `bootstrap-host.sh` is downloaded from the public shared repository.
+- Private fork-specific `bootstrap-host.sh` files are not supported by streamed setup.
+- To use a private fork-specific bootstrap script, clone the repository first and run its local `scripts/setup.sh`.
+
 ### Optional Docker Engine Setup
 
 The shared Home Manager configuration installs the Docker CLI tools.

--- a/docs/91-repository-structure.md
+++ b/docs/91-repository-structure.md
@@ -60,8 +60,10 @@ When a module installs a tool and also wants to provide a default shared config,
 
 This directory contains imperative shell entry points.
 
-- `scripts/setup.sh` is the bootstrap-oriented entry point.
-  - It prepares prerequisites such as Nix and Git when needed.
+- `scripts/bootstrap-host.sh` prepares the host for setup by installing Nix and offering optional GitHub SSH access
+  and Docker Engine setup.
+- `scripts/setup.sh` is the script-based setup entry point.
+  - It prepares the host for setup through `scripts/bootstrap-host.sh`.
   - It clones this repository into the install location.
   - It is designed for users who start from a plain Ubuntu environment.
 - `scripts/apply.sh` applies this repository's shared configuration into the current user environment.

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# shellcheck source=scripts/bootstrap-host.sh
+. "${repo_root}/scripts/bootstrap-host.sh"
+
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
 export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 
@@ -91,68 +94,6 @@ ensure_nix_conf_include() {
     "# >>> ISSL nix config >>>" \
     "# <<< ISSL nix config <<<" \
     "$(nix_conf_include_block)"
-}
-
-is_systemd_available() {
-  [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
-}
-
-resolve_nix_daemon_path() {
-  if command -v nix-daemon >/dev/null 2>&1; then
-    command -v nix-daemon
-    return 0
-  fi
-
-  if [ -x /nix/var/nix/profiles/default/bin/nix-daemon ]; then
-    printf '%s\n' "/nix/var/nix/profiles/default/bin/nix-daemon"
-    return 0
-  fi
-
-  return 1
-}
-
-start_nix_daemon_without_systemd() {
-  local nix_daemon_path=""
-
-  if is_systemd_available; then
-    return
-  fi
-
-  if pgrep -x nix-daemon >/dev/null 2>&1; then
-    return
-  fi
-
-  if ! nix_daemon_path="$(resolve_nix_daemon_path)"; then
-    echo "warning: nix-daemon binary was not found. Nix commands may fail in no-systemd environments." >&2
-    return
-  fi
-
-  if [ "$(id -u)" = "0" ]; then
-    setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
-  elif command -v sudo >/dev/null 2>&1; then
-    if [ -t 0 ]; then
-      if ! sudo -v; then
-        echo "warning: failed to authenticate via sudo. Nix commands may fail." >&2
-        return
-      fi
-    elif ! sudo -n true >/dev/null 2>&1; then
-      echo "warning: cannot start nix-daemon automatically (sudo requires a password in non-interactive mode)." >&2
-      return
-    fi
-    sudo -n setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
-  else
-    echo "warning: cannot start nix-daemon automatically (sudo is unavailable in a no-systemd environment)." >&2
-    return
-  fi
-
-  for _ in {1..10}; do
-    if nix --extra-experimental-features "nix-command flakes" store info >/dev/null 2>&1; then
-      return
-    fi
-    sleep 1
-  done
-
-  echo "warning: attempted to start nix-daemon, but it is not responding yet. Nix commands may fail." >&2
 }
 
 # ===== Bash ===== #

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -510,49 +510,53 @@ ensure_cargo_config_include() {
     "$(cargo_config_include_block)"
 }
 
-if ! command -v nix >/dev/null 2>&1; then
-  echo "nix is required before running scripts/apply.sh." >&2
-  exit 1
-fi
+main() {
+  if ! command -v nix >/dev/null 2>&1; then
+    echo "nix is required before running scripts/apply.sh." >&2
+    exit 1
+  fi
 
-if [ -n "${NIX_CONFIG-}" ]; then
-  export NIX_CONFIG="${NIX_CONFIG}"$'\n'"${nix_feature_config}"
-else
-  export NIX_CONFIG="${nix_feature_config}"
-fi
+  if [ -n "${NIX_CONFIG-}" ]; then
+    export NIX_CONFIG="${NIX_CONFIG}"$'\n'"${nix_feature_config}"
+  else
+    export NIX_CONFIG="${nix_feature_config}"
+  fi
 
-start_nix_daemon_without_systemd
+  start_nix_daemon_without_systemd
 
-current_system="$(
-  nix --accept-flake-config --extra-experimental-features "nix-command flakes" \
-    eval --impure --raw --expr builtins.currentSystem
-)"
+  current_system="$(
+    nix --accept-flake-config --extra-experimental-features "nix-command flakes" \
+      eval --impure --raw --expr builtins.currentSystem
+  )"
 
-ensure_home_manager_profile_dir
-if should_enable_zsh; then
-  home_configuration_name="issl-common-zsh-${current_system}"
-  zsh_enabled=1
-else
-  home_configuration_name="issl-common-${current_system}"
-  zsh_enabled=0
-fi
+  ensure_home_manager_profile_dir
+  if should_enable_zsh; then
+    home_configuration_name="issl-common-zsh-${current_system}"
+    zsh_enabled=1
+  else
+    home_configuration_name="issl-common-${current_system}"
+    zsh_enabled=0
+  fi
 
-if [ "${zsh_enabled}" = "0" ]; then
-  guard_login_shell_before_disabling_zsh
-fi
+  if [ "${zsh_enabled}" = "0" ]; then
+    guard_login_shell_before_disabling_zsh
+  fi
 
-nix --accept-flake-config --extra-experimental-features "nix-command flakes" run "${repo_root}#home-manager" -- \
-  switch --flake "${repo_root}#${home_configuration_name}" --impure
+  nix --accept-flake-config --extra-experimental-features "nix-command flakes" run "${repo_root}#home-manager" -- \
+    switch --flake "${repo_root}#${home_configuration_name}" --impure
 
-ensure_nix_conf_include
-ensure_bash_startup_files
-if [ "${zsh_enabled}" = "1" ]; then
-  ensure_zsh_startup_files
-  maybe_switch_login_shell_to_zsh
-fi
-ensure_git_include
-prompt_for_git_identity
-ensure_python_startup_file
-ensure_cargo_config_include
+  ensure_nix_conf_include
+  ensure_bash_startup_files
+  if [ "${zsh_enabled}" = "1" ]; then
+    ensure_zsh_startup_files
+    maybe_switch_login_shell_to_zsh
+  fi
+  ensure_git_include
+  prompt_for_git_identity
+  ensure_python_startup_file
+  ensure_cargo_config_include
 
-echo "Applied the shared Home Manager configuration."
+  echo "Applied the shared Home Manager configuration."
+}
+
+main "$@"

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -155,15 +155,15 @@ start_nix_daemon_without_systemd() {
   echo "warning: attempted to start nix-daemon, but it is not responding yet. Nix commands may fail." >&2
 }
 
+nix_with_openssh() {
+  nix --extra-experimental-features "nix-command flakes" shell nixpkgs#openssh --command "$@"
+}
+
 has_github_ssh_auth() {
   local ssh_output
   local ssh_status
 
-  if ! command -v ssh >/dev/null 2>&1; then
-    return 1
-  fi
-
-  ssh_output="$(ssh -T git@github.com 2>&1)" || ssh_status=$?
+  ssh_output="$(nix_with_openssh ssh -T git@github.com 2>&1)" || ssh_status=$?
   ssh_status="${ssh_status:-0}"
 
   if [ "${ssh_status}" -eq 1 ] &&
@@ -187,14 +187,13 @@ create_github_ssh_key() {
   local key_comment=""
 
   ensure_ssh_directory
-  require_command ssh-keygen
 
   read -r -p "Enter an email/comment for the GitHub SSH key (optional): " key_comment
 
   if [ -n "${key_comment}" ]; then
-    ssh-keygen -t ed25519 -C "${key_comment}" -f "${github_key_path}"
+    nix_with_openssh ssh-keygen -t ed25519 -C "${key_comment}" -f "${github_key_path}"
   else
-    ssh-keygen -t ed25519 -f "${github_key_path}"
+    nix_with_openssh ssh-keygen -t ed25519 -f "${github_key_path}"
   fi
 }
 

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -93,6 +93,68 @@ ensure_nix() {
   source_nix
 }
 
+is_systemd_available() {
+  [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
+}
+
+resolve_nix_daemon_path() {
+  if command -v nix-daemon >/dev/null 2>&1; then
+    command -v nix-daemon
+    return 0
+  fi
+
+  if [ -x /nix/var/nix/profiles/default/bin/nix-daemon ]; then
+    printf '%s\n' "/nix/var/nix/profiles/default/bin/nix-daemon"
+    return 0
+  fi
+
+  return 1
+}
+
+start_nix_daemon_without_systemd() {
+  local nix_daemon_path=""
+
+  if is_systemd_available; then
+    return
+  fi
+
+  if pgrep -x nix-daemon >/dev/null 2>&1; then
+    return
+  fi
+
+  if ! nix_daemon_path="$(resolve_nix_daemon_path)"; then
+    echo "warning: nix-daemon binary was not found. Nix commands may fail in no-systemd environments." >&2
+    return
+  fi
+
+  if [ "$(id -u)" = "0" ]; then
+    setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
+  elif command -v sudo >/dev/null 2>&1; then
+    if [ -t 0 ]; then
+      if ! sudo -v; then
+        echo "warning: failed to authenticate via sudo. Nix commands may fail." >&2
+        return
+      fi
+    elif ! sudo -n true >/dev/null 2>&1; then
+      echo "warning: cannot start nix-daemon automatically (sudo requires a password in non-interactive mode)." >&2
+      return
+    fi
+    sudo -n setsid "${nix_daemon_path}" --daemon >/dev/null 2>&1 &
+  else
+    echo "warning: cannot start nix-daemon automatically (sudo is unavailable in a no-systemd environment)." >&2
+    return
+  fi
+
+  for _ in {1..10}; do
+    if nix --extra-experimental-features "nix-command flakes" store info >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+
+  echo "warning: attempted to start nix-daemon, but it is not responding yet. Nix commands may fail." >&2
+}
+
 has_github_ssh_auth() {
   local ssh_output
   local ssh_status
@@ -293,6 +355,7 @@ maybe_install_docker_engine() {
 
 bootstrap_host() {
   ensure_nix
+  start_nix_daemon_without_systemd
   maybe_offer_github_ssh_setup
   maybe_install_docker_engine
 }

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ssh_dir="${HOME}/.ssh"
+github_key_path="${ssh_dir}/github_ed25519"
+ssh_config_path="${ssh_dir}/config"
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "required command not found: ${command_name}" >&2
+    exit 1
+  fi
+}
+
+is_interactive() {
+  [ -t 0 ] && [ -t 1 ]
+}
+
+is_yes() {
+  case "${1-}" in
+  y | Y | yes | YES | Yes | true | TRUE | True | 1) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+is_no() {
+  case "${1-}" in
+  n | N | no | NO | No | false | FALSE | False | 0) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+prompt_yes_no() {
+  local prompt_message="$1"
+  local default_answer="${2:-no}"
+  local reply
+
+  if ! is_interactive; then
+    return 1
+  fi
+
+  if ! read -r -p "${prompt_message} " reply; then
+    return 1
+  fi
+
+  if [ -z "${reply}" ]; then
+    is_yes "${default_answer}"
+    return
+  fi
+
+  is_yes "${reply}"
+}
+
+source_nix() {
+  if command -v nix >/dev/null 2>&1; then
+    return
+  fi
+
+  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    # Official multi-user installs expose Nix through this profile script.
+    # shellcheck source=/dev/null
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  elif [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+    # Fallback for single-user installs.
+    # shellcheck source=/dev/null
+    . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+  fi
+
+  if ! command -v nix >/dev/null 2>&1; then
+    echo "nix is installed but was not added to PATH in the current shell." >&2
+    exit 1
+  fi
+}
+
+ensure_nix() {
+  if command -v nix >/dev/null 2>&1; then
+    return
+  fi
+
+  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ] ||
+    [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+    source_nix
+    return
+  fi
+
+  require_command curl
+  require_command sh
+
+  sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemon
+  source_nix
+}
+
+has_github_ssh_auth() {
+  local ssh_output
+  local ssh_status
+
+  if ! command -v ssh >/dev/null 2>&1; then
+    return 1
+  fi
+
+  ssh_output="$(ssh -T git@github.com 2>&1)" || ssh_status=$?
+  ssh_status="${ssh_status:-0}"
+
+  if [ "${ssh_status}" -eq 1 ] &&
+    printf '%s\n' "${ssh_output}" | grep -Fq "successfully authenticated"; then
+    return 0
+  fi
+
+  return 1
+}
+
+ensure_ssh_directory() {
+  mkdir -p "${ssh_dir}"
+  chmod 700 "${ssh_dir}"
+}
+
+github_ssh_key_exists() {
+  [ -f "${github_key_path}" ] && [ -f "${github_key_path}.pub" ]
+}
+
+create_github_ssh_key() {
+  local key_comment=""
+
+  ensure_ssh_directory
+  require_command ssh-keygen
+
+  read -r -p "Enter an email/comment for the GitHub SSH key (optional): " key_comment
+
+  if [ -n "${key_comment}" ]; then
+    ssh-keygen -t ed25519 -C "${key_comment}" -f "${github_key_path}"
+  else
+    ssh-keygen -t ed25519 -f "${github_key_path}"
+  fi
+}
+
+ensure_github_ssh_config() {
+  ensure_ssh_directory
+
+  if [ -f "${ssh_config_path}" ] &&
+    grep -Eq '^[[:space:]]*[Hh][Oo][Ss][Tt][[:space:]]+github\.com([[:space:]]|$)' "${ssh_config_path}"; then
+    return
+  fi
+
+  {
+    echo "Host github.com"
+    echo "  HostName github.com"
+    echo "  User git"
+    echo "  IdentityFile ~/.ssh/github_ed25519"
+  } >>"${ssh_config_path}"
+  chmod 600 "${ssh_config_path}"
+}
+
+prompt_github_ssh_registration() {
+  echo "Register the following public key in GitHub:"
+  echo "https://github.com/settings/keys"
+  echo
+  cat "${github_key_path}.pub"
+  echo
+
+  if ! prompt_yes_no "Type yes after the key has been registered in GitHub."; then
+    echo "GitHub SSH key registration was not confirmed." >&2
+    exit 1
+  fi
+}
+
+prompt_github_ssh_setup() {
+  if ! github_ssh_key_exists; then
+    if ! prompt_yes_no "No GitHub SSH key was found at ${github_key_path}. Create one now? [y/N]"; then
+      return
+    fi
+
+    create_github_ssh_key
+  fi
+
+  ensure_github_ssh_config
+  prompt_github_ssh_registration
+}
+
+maybe_offer_github_ssh_setup() {
+  if ! is_interactive; then
+    return
+  fi
+
+  if has_github_ssh_auth; then
+    return
+  fi
+
+  if ! prompt_yes_no "Set up GitHub SSH access now for future private repository use? [Y/n]" yes; then
+    return
+  fi
+
+  prompt_github_ssh_setup
+}
+
+should_install_docker() {
+  if is_yes "${ISSL_INSTALL_DOCKER-}"; then
+    return 0
+  fi
+
+  if is_no "${ISSL_INSTALL_DOCKER-}"; then
+    return 1
+  fi
+
+  if ! is_interactive; then
+    return 1
+  fi
+
+  prompt_yes_no "Install Docker Engine for local container execution? [Y/n]" yes
+}
+
+should_add_user_to_docker_group() {
+  if is_no "${ISSL_ADD_USER_TO_DOCKER_GROUP-}"; then
+    return 1
+  fi
+
+  if is_yes "${ISSL_ADD_USER_TO_DOCKER_GROUP-}"; then
+    return 0
+  fi
+
+  return 0
+}
+
+target_docker_user() {
+  if [ -n "${SUDO_USER-}" ] && [ "${SUDO_USER}" != "root" ]; then
+    printf '%s\n' "${SUDO_USER}"
+  elif [ -n "${USER-}" ]; then
+    printf '%s\n' "${USER}"
+  else
+    id -un
+  fi
+}
+
+install_docker_engine() {
+  local apt_keyrings_dir="/etc/apt/keyrings"
+  local docker_user=""
+  local ubuntu_codename=""
+
+  require_command sudo
+  require_command apt-get
+  require_command dpkg
+
+  if [ -r /etc/os-release ]; then
+    # shellcheck source=/dev/null
+    . /etc/os-release
+  fi
+
+  ubuntu_codename="${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}"
+  if [ -z "${ubuntu_codename}" ]; then
+    echo "could not determine the Ubuntu codename for Docker repository setup." >&2
+    exit 1
+  fi
+
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates curl gnupg
+  require_command curl
+  require_command gpg
+  sudo install -m 0755 -d "${apt_keyrings_dir}"
+
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
+    gpg --dearmor |
+    sudo tee "${apt_keyrings_dir}/docker.gpg" >/dev/null
+  sudo chmod a+r "${apt_keyrings_dir}/docker.gpg"
+
+  printf 'deb [arch=%s signed-by=%s/docker.gpg] https://download.docker.com/linux/ubuntu %s stable\n' \
+    "$(dpkg --print-architecture)" "${apt_keyrings_dir}" "${ubuntu_codename}" |
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+  sudo apt-get update
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+  if should_add_user_to_docker_group; then
+    docker_user="$(target_docker_user)"
+    sudo usermod -aG docker "${docker_user}"
+    echo "Added ${docker_user} to the docker group."
+    echo "Log out and back in, or run 'newgrp docker', before using Docker without sudo."
+  fi
+
+  if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+    sudo systemctl enable --now docker.service
+  fi
+}
+
+maybe_install_docker_engine() {
+  if ! should_install_docker; then
+    return
+  fi
+
+  install_docker_engine
+}
+
+bootstrap_host() {
+  ensure_nix
+  maybe_offer_github_ssh_setup
+  maybe_install_docker_engine
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  bootstrap_host
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -144,7 +144,7 @@ load_bootstrap_host() {
 }
 
 nix_with_git() {
-  nix --extra-experimental-features "nix-command flakes" shell nixpkgs#git --command "$@"
+  nix --extra-experimental-features "nix-command flakes" shell nixpkgs#git nixpkgs#openssh --command "$@"
 }
 
 nix_git() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -141,8 +141,12 @@ load_bootstrap_host() {
   exit 1
 }
 
+nix_with_git() {
+  nix --extra-experimental-features "nix-command flakes" shell nixpkgs#git --command "$@"
+}
+
 nix_git() {
-  nix --extra-experimental-features "nix-command flakes" shell nixpkgs#git --command git "$@"
+  nix_with_git git "$@"
 }
 
 can_access_repo() {
@@ -207,7 +211,7 @@ clone_repo() {
 }
 
 run_install() {
-  bash "${install_dir}/scripts/apply.sh"
+  nix_with_git bash "${install_dir}/scripts/apply.sh"
 }
 
 main() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 default_repo_ref="v0.3.1"
+default_bootstrap_repository_path="ut-issl/issl-ubuntu-environment-setup"
 repo_url="${REPO_URL:-https://github.com/ut-issl/issl-ubuntu-environment-setup.git}"
 repo_ref="${REPO_REF:-${default_repo_ref}}"
 data_root="${XDG_DATA_HOME:-$HOME/.local/share}"
@@ -47,10 +48,21 @@ github_repository_path() {
   printf '%s/%s\n' "${owner}" "${repo}"
 }
 
+bootstrap_repository_path() {
+  case "${repo_url}" in
+  git@github.com:* | ssh://git@github.com/*)
+    printf '%s\n' "${default_bootstrap_repository_path}"
+    ;;
+  *)
+    github_repository_path
+    ;;
+  esac
+}
+
 raw_bootstrap_url() {
   local repository_path
 
-  repository_path="$(github_repository_path)"
+  repository_path="$(bootstrap_repository_path)"
 
   printf 'https://raw.githubusercontent.com/%s/%s/scripts/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
 }
@@ -58,7 +70,7 @@ raw_bootstrap_url() {
 release_bootstrap_url() {
   local repository_path
 
-  repository_path="$(github_repository_path)"
+  repository_path="$(bootstrap_repository_path)"
 
   printf 'https://github.com/%s/releases/download/%s/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,23 +47,37 @@ github_repository_path() {
   printf '%s/%s\n' "${owner}" "${repo}"
 }
 
-default_bootstrap_url() {
+raw_bootstrap_url() {
   local repository_path
 
   repository_path="$(github_repository_path)"
 
+  printf 'https://raw.githubusercontent.com/%s/%s/scripts/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
+}
+
+release_bootstrap_url() {
+  local repository_path
+
+  repository_path="$(github_repository_path)"
+
+  printf 'https://github.com/%s/releases/download/%s/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
+}
+
+default_bootstrap_urls() {
   case "${repo_ref}" in
   v*)
-    printf 'https://github.com/%s/releases/download/%s/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
+    release_bootstrap_url
+    raw_bootstrap_url
     ;;
   *)
-    printf 'https://raw.githubusercontent.com/%s/%s/scripts/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
+    raw_bootstrap_url
     ;;
   esac
 }
 
 load_bootstrap_host() {
-  local bootstrap_url="${BOOTSTRAP_URL:-$(default_bootstrap_url)}"
+  local bootstrap_url=""
+  local bootstrap_urls="${BOOTSTRAP_URL:-$(default_bootstrap_urls)}"
   local script_dir=""
   local temporary_bootstrap=""
 
@@ -81,9 +95,18 @@ load_bootstrap_host() {
   fi
 
   temporary_bootstrap="$(mktemp)"
-  curl -fsSL "${bootstrap_url}" -o "${temporary_bootstrap}"
-  # shellcheck source=/dev/null
-  . "${temporary_bootstrap}"
+  while IFS= read -r bootstrap_url; do
+    [ -n "${bootstrap_url}" ] || continue
+
+    if curl -fsSL "${bootstrap_url}" -o "${temporary_bootstrap}"; then
+      # shellcheck source=/dev/null
+      . "${temporary_bootstrap}"
+      return
+    fi
+  done <<<"${bootstrap_urls}"
+
+  echo "failed to download bootstrap-host.sh." >&2
+  exit 1
 }
 
 nix_git() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,137 +7,48 @@ repo_url="${REPO_URL:-https://github.com/ut-issl/issl-ubuntu-environment-setup.g
 repo_ref="${REPO_REF:-${default_repo_ref}}"
 data_root="${XDG_DATA_HOME:-$HOME/.local/share}"
 install_dir="${INSTALL_DIR:-$data_root/issl/ubuntu-environment-setup}"
-ssh_dir="${HOME}/.ssh"
-github_key_path="${ssh_dir}/github_ed25519"
-ssh_config_path="${ssh_dir}/config"
-temporary_git_installed=false
 
-is_interactive() {
-  [ -t 0 ] && [ -t 1 ]
-}
-
-prepend_path_if_exists() {
-  local path_entry="$1"
-
-  [ -d "${path_entry}" ] || return
-
-  case ":${PATH}:" in
-  *:"${path_entry}":*) ;;
-  *) PATH="${path_entry}:${PATH}" ;;
-  esac
-}
-
-refresh_path_for_nix() {
-  prepend_path_if_exists "${HOME}/.nix-profile/bin"
-  prepend_path_if_exists "/nix/var/nix/profiles/default/bin"
-
-  if [ -n "${USER:-}" ]; then
-    prepend_path_if_exists "/nix/var/nix/profiles/per-user/${USER}/profile/bin"
-  fi
-
-  hash -r 2>/dev/null || true
-}
-
-require_command() {
-  local command_name="$1"
-
-  if ! command -v "${command_name}" >/dev/null 2>&1; then
-    echo "required command not found: ${command_name}" >&2
-    exit 1
-  fi
-}
-
-prompt_yes_no() {
-  local prompt_message="$1"
-  local default_answer="${2:-no}"
-  local reply
-
-  if ! is_interactive; then
-    return 1
-  fi
-
-  if ! read -r -p "${prompt_message} " reply; then
-    return 1
-  fi
-
-  if [ -z "${reply}" ]; then
-    case "${default_answer}" in
-    y | Y | yes | YES | Yes)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-    esac
-  fi
-
-  case "${reply}" in
-  y | Y | yes | YES | Yes)
-    return 0
+default_bootstrap_url() {
+  case "${repo_ref}" in
+  v*)
+    printf 'https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/download/%s/bootstrap-host.sh\n' "${repo_ref}"
     ;;
   *)
-    return 1
+    printf 'https://raw.githubusercontent.com/ut-issl/issl-ubuntu-environment-setup/%s/scripts/bootstrap-host.sh\n' "${repo_ref}"
     ;;
   esac
 }
 
-source_nix() {
-  if command -v nix >/dev/null 2>&1; then
+load_bootstrap_host() {
+  local bootstrap_url="${BOOTSTRAP_URL:-$(default_bootstrap_url)}"
+  local script_dir=""
+  local temporary_bootstrap=""
+
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+  if [ -f "${script_dir}/bootstrap-host.sh" ]; then
+    # shellcheck source=scripts/bootstrap-host.sh
+    . "${script_dir}/bootstrap-host.sh"
     return
   fi
 
-  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
-    # Official multi-user installs expose Nix through this profile script.
-    # shellcheck source=/dev/null
-    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-  elif [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
-    # Fallback for single-user installs.
-    # shellcheck source=/dev/null
-    . "$HOME/.nix-profile/etc/profile.d/nix.sh"
-  fi
-
-  if ! command -v nix >/dev/null 2>&1; then
-    echo "nix is installed but was not added to PATH in the current shell." >&2
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "required command not found: curl" >&2
     exit 1
   fi
+
+  temporary_bootstrap="$(mktemp)"
+  curl -fsSL "${bootstrap_url}" -o "${temporary_bootstrap}"
+  # shellcheck source=/dev/null
+  . "${temporary_bootstrap}"
 }
 
-ensure_nix() {
-  if command -v nix >/dev/null 2>&1; then
-    return
-  fi
-
-  require_command curl
-  require_command sh
-
-  sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemon
-  source_nix
-}
-
-ensure_git() {
-  if command -v git >/dev/null 2>&1; then
-    return
-  fi
-
-  require_command sudo
-  require_command apt-get
-
-  sudo apt-get update
-  sudo apt-get install -y git
-  temporary_git_installed=true
-}
-
-ensure_ssh_directory() {
-  mkdir -p "${ssh_dir}"
-  chmod 700 "${ssh_dir}"
-}
-
-github_ssh_key_exists() {
-  [ -f "${github_key_path}" ] && [ -f "${github_key_path}.pub" ]
+nix_git() {
+  nix --extra-experimental-features "nix-command flakes" shell nixpkgs#git --command git "$@"
 }
 
 can_access_repo() {
-  git ls-remote --exit-code "${repo_url}" "${repo_ref}" >/dev/null 2>&1
+  nix_git ls-remote --exit-code "${repo_url}" "${repo_ref}" >/dev/null 2>&1
 }
 
 is_github_ssh_repo_url() {
@@ -151,104 +62,7 @@ is_github_ssh_repo_url() {
   esac
 }
 
-ensure_github_ssh_config() {
-  ensure_ssh_directory
-
-  if [ -f "${ssh_config_path}" ] &&
-    grep -Eq '^[[:space:]]*[Hh][Oo][Ss][Tt][[:space:]]+github\.com([[:space:]]|$)' "${ssh_config_path}"; then
-    return
-  fi
-
-  {
-    echo "Host github.com"
-    echo "  HostName github.com"
-    echo "  User git"
-    echo "  IdentityFile ~/.ssh/github_ed25519"
-  } >>"${ssh_config_path}"
-  chmod 600 "${ssh_config_path}"
-}
-
-create_github_ssh_key() {
-  local key_comment=""
-
-  ensure_ssh_directory
-  require_command ssh-keygen
-
-  read -r -p "Enter an email/comment for the GitHub SSH key (optional): " key_comment
-
-  if [ -n "${key_comment}" ]; then
-    ssh-keygen -t ed25519 -C "${key_comment}" -f "${github_key_path}"
-  else
-    ssh-keygen -t ed25519 -f "${github_key_path}"
-  fi
-}
-
-prompt_github_ssh_registration() {
-  echo "Register the following public key in GitHub:"
-  echo "https://github.com/settings/keys"
-  echo
-  cat "${github_key_path}.pub"
-  echo
-
-  if ! prompt_yes_no "Type yes after the key has been registered in GitHub."; then
-    echo "GitHub SSH key registration was not confirmed." >&2
-    exit 1
-  fi
-}
-
-prompt_github_ssh_setup() {
-  if ! github_ssh_key_exists; then
-    if ! prompt_yes_no "No GitHub SSH key was found at ${github_key_path}. Create one now? [y/N]"; then
-      return
-    fi
-
-    create_github_ssh_key
-  fi
-
-  ensure_github_ssh_config
-  prompt_github_ssh_registration
-}
-
-has_github_ssh_auth() {
-  local ssh_output
-  local ssh_status
-
-  if ! command -v ssh >/dev/null 2>&1; then
-    return 1
-  fi
-
-  ssh_output="$(ssh -T git@github.com 2>&1)" || ssh_status=$?
-  ssh_status="${ssh_status:-0}"
-
-  if [ "${ssh_status}" -eq 1 ] &&
-    printf '%s\n' "${ssh_output}" | grep -Fq "successfully authenticated"; then
-    return 0
-  fi
-
-  return 1
-}
-
-maybe_offer_github_ssh_setup() {
-  if ! is_interactive; then
-    return
-  fi
-
-  if has_github_ssh_auth; then
-    return
-  fi
-
-  if ! prompt_yes_no "Set up GitHub SSH access now for future private repository use? [Y/n]" yes; then
-    return
-  fi
-
-  prompt_github_ssh_setup
-}
-
 try_github_ssh_recovery() {
-  if ! is_github_ssh_repo_url; then
-    return 1
-  fi
-
   if has_github_ssh_auth; then
     return 1
   fi
@@ -278,7 +92,7 @@ ensure_repo_access() {
     return
   fi
 
-  if try_github_ssh_recovery; then
+  if is_github_ssh_repo_url && try_github_ssh_recovery; then
     return
   fi
 
@@ -291,44 +105,19 @@ clone_repo() {
     exit 1
   fi
 
-  git clone --branch "${repo_ref}" --single-branch "${repo_url}" "${install_dir}"
+  nix_git clone --branch "${repo_ref}" --single-branch "${repo_url}" "${install_dir}"
 }
 
 run_install() {
   bash "${install_dir}/scripts/apply.sh"
 }
 
-cleanup_temporary_git() {
-  if [ "${temporary_git_installed}" != "true" ]; then
-    return
-  fi
-
-  source_nix
-  refresh_path_for_nix
-
-  if ! command -v git >/dev/null 2>&1; then
-    echo "git is not available after setup; keeping the apt-installed git." >&2
-    return
-  fi
-
-  case "$(command -v git)" in
-  /nix/store/* | "$HOME"/.nix-profile/* | /nix/var/nix/profiles/*)
-    sudo apt-get remove -y git
-    ;;
-  *)
-    echo "git is still resolved outside Nix; keeping the apt-installed git." >&2
-    ;;
-  esac
-}
-
 main() {
-  ensure_nix
-  ensure_git
-  maybe_offer_github_ssh_setup
+  load_bootstrap_host
+  bootstrap_host
   ensure_repo_access
   clone_repo
   run_install
-  cleanup_temporary_git
 
   echo "ISSL environment setup completed."
   echo "Repository clone: ${install_dir}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -109,7 +109,7 @@ default_bootstrap_urls() {
 
 load_bootstrap_host() {
   local bootstrap_url=""
-  local bootstrap_urls="${BOOTSTRAP_URL:-$(default_bootstrap_urls)}"
+  local bootstrap_urls=""
   local script_dir=""
   local temporary_bootstrap=""
 
@@ -120,6 +120,8 @@ load_bootstrap_host() {
     . "${script_dir}/bootstrap-host.sh"
     return
   fi
+
+  bootstrap_urls="${BOOTSTRAP_URL:-$(default_bootstrap_urls)}"
 
   if ! command -v curl >/dev/null 2>&1; then
     echo "required command not found: curl" >&2

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,24 +59,44 @@ bootstrap_repository_path() {
   esac
 }
 
+bootstrap_ref() {
+  if [ -n "${BOOTSTRAP_REF-}" ]; then
+    printf '%s\n' "${BOOTSTRAP_REF}"
+    return
+  fi
+
+  case "${repo_url}" in
+  git@github.com:* | ssh://git@github.com/*)
+    printf '%s\n' "${default_repo_ref}"
+    ;;
+  *)
+    printf '%s\n' "${repo_ref}"
+    ;;
+  esac
+}
+
 raw_bootstrap_url() {
+  local bootstrap_ref_value
   local repository_path
 
+  bootstrap_ref_value="$(bootstrap_ref)"
   repository_path="$(bootstrap_repository_path)"
 
-  printf 'https://raw.githubusercontent.com/%s/%s/scripts/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
+  printf 'https://raw.githubusercontent.com/%s/%s/scripts/bootstrap-host.sh\n' "${repository_path}" "${bootstrap_ref_value}"
 }
 
 release_bootstrap_url() {
+  local bootstrap_ref_value
   local repository_path
 
+  bootstrap_ref_value="$(bootstrap_ref)"
   repository_path="$(bootstrap_repository_path)"
 
-  printf 'https://github.com/%s/releases/download/%s/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
+  printf 'https://github.com/%s/releases/download/%s/bootstrap-host.sh\n' "${repository_path}" "${bootstrap_ref_value}"
 }
 
 default_bootstrap_urls() {
-  case "${repo_ref}" in
+  case "$(bootstrap_ref)" in
   v*)
     release_bootstrap_url
     raw_bootstrap_url

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,13 +8,56 @@ repo_ref="${REPO_REF:-${default_repo_ref}}"
 data_root="${XDG_DATA_HOME:-$HOME/.local/share}"
 install_dir="${INSTALL_DIR:-$data_root/issl/ubuntu-environment-setup}"
 
-default_bootstrap_url() {
-  case "${repo_ref}" in
-  v*)
-    printf 'https://github.com/ut-issl/issl-ubuntu-environment-setup/releases/download/%s/bootstrap-host.sh\n' "${repo_ref}"
+github_repository_path() {
+  local path=""
+  local owner=""
+  local repo=""
+
+  case "${repo_url}" in
+  https://github.com/*)
+    path="${repo_url#https://github.com/}"
+    ;;
+  git@github.com:*)
+    path="${repo_url#git@github.com:}"
+    ;;
+  ssh://git@github.com/*)
+    path="${repo_url#ssh://git@github.com/}"
     ;;
   *)
-    printf 'https://raw.githubusercontent.com/ut-issl/issl-ubuntu-environment-setup/%s/scripts/bootstrap-host.sh\n' "${repo_ref}"
+    echo "unsupported GitHub repository URL for bootstrap download: ${repo_url}" >&2
+    exit 1
+    ;;
+  esac
+
+  path="${path%.git}"
+  if [ "${path}" = "${path#*/}" ]; then
+    echo "unsupported GitHub repository URL for bootstrap download: ${repo_url}" >&2
+    exit 1
+  fi
+
+  owner="${path%%/*}"
+  repo="${path#*/}"
+  repo="${repo%%/*}"
+
+  if [ -z "${owner}" ] || [ -z "${repo}" ]; then
+    echo "unsupported GitHub repository URL for bootstrap download: ${repo_url}" >&2
+    exit 1
+  fi
+
+  printf '%s/%s\n' "${owner}" "${repo}"
+}
+
+default_bootstrap_url() {
+  local repository_path
+
+  repository_path="$(github_repository_path)"
+
+  case "${repo_ref}" in
+  v*)
+    printf 'https://github.com/%s/releases/download/%s/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
+    ;;
+  *)
+    printf 'https://raw.githubusercontent.com/%s/%s/scripts/bootstrap-host.sh\n' "${repository_path}" "${repo_ref}"
     ;;
   esac
 }


### PR DESCRIPTION
- Split host preparation into `scripts/bootstrap-host.sh` so it can be reused outside the script-based setup flow.
- Keep repository cloning in `scripts/setup.sh` and run Git through Nix instead of installing Git with apt.
- Add optional Docker Engine setup guidance and include the bootstrap script in release assets.

Refs #366