### PR TITLE
chore: allow long markdown code blocks

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,3 +4,4 @@ gitignore: true
 config:
   MD013:
     line_length: 120
+    code_blocks: false


### PR DESCRIPTION
- Exclude fenced code blocks from the Markdown line-length rule.
- Keep long setup commands intact in documentation instead of rewriting them for linting.