### PR TITLE
fix(python): make pythonrc compatible with Python 3.13+ pyrepl and libedit

### DIFF
--- a/assets/python/pythonrc.py
+++ b/assets/python/pythonrc.py
@@ -58,7 +58,10 @@ def _enable_completion() -> None:
 
 
 def _ensure_history_dir() -> None:
-    histdir = os.path.dirname(_history_base_path())
+    base = _history_base_path()
+    if "PYTHON_HISTORY" not in os.environ:
+        os.environ["PYTHON_HISTORY"] = base
+    histdir = os.path.dirname(base)
     if histdir:
         os.makedirs(histdir, exist_ok=True)
 

--- a/assets/python/pythonrc.py
+++ b/assets/python/pythonrc.py
@@ -2,28 +2,65 @@
 
 from __future__ import annotations
 
-import atexit
 import builtins
 import os
-import readline
 import sys
 from pprint import pprint
 
 
-def _history_path() -> str:
-    histfile = os.environ.get("PYTHONHISTFILE")
-    if histfile:
-        return histfile
+def _will_use_pyrepl() -> bool:
+    if sys.version_info < (3, 13):
+        return False
+    if os.environ.get("PYTHON_BASIC_REPL"):
+        return False
+    if not sys.stdin.isatty():
+        return False
+    try:
+        from _pyrepl.main import CAN_USE_PYREPL  # type: ignore[import-not-found]
 
+        return CAN_USE_PYREPL
+    except (ImportError, AttributeError):  # fmt: skip
+        return False
+
+
+def _is_libedit() -> bool:
+    try:
+        import readline
+    except ImportError:
+        return False
+    if sys.version_info >= (3, 13):
+        return getattr(readline, "backend", "") == "editline"
+    return "libedit" in getattr(readline, "__doc__", "")
+
+
+def _history_base_path() -> str:
+    path = os.environ.get("PYTHON_HISTORY")
+    if path:
+        return path
     state_home = os.environ.get("XDG_STATE_HOME") or os.path.join(os.path.expanduser("~"), ".local", "state")
     return os.path.join(state_home, "python", "python_history")
 
 
+def _history_path() -> str:
+    base = _history_base_path()
+    if _is_libedit():
+        return base + ".editline"
+    return base
+
+
 def _enable_completion() -> None:
-    readline.parse_and_bind("tab: complete")
+    import readline
+
+    if _is_libedit():
+        readline.parse_and_bind("bind ^I rl_complete")
+    else:
+        readline.parse_and_bind("tab: complete")
 
 
 def _enable_history() -> None:
+    import atexit
+    import readline
+
     histfile = _history_path()
     histdir = os.path.dirname(histfile)
     if histdir:
@@ -33,7 +70,7 @@ def _enable_history() -> None:
         try:
             readline.read_history_file(histfile)
         except Exception:
-            pass
+            return
 
     readline.set_history_length(10_000)
 
@@ -44,6 +81,14 @@ def _enable_history() -> None:
             pass
 
     atexit.register(save_history)
+
+
+def _redirect_history_for_libedit() -> None:
+    path = _history_path()
+    histdir = os.path.dirname(path)
+    if histdir:
+        os.makedirs(histdir, exist_ok=True)
+    os.environ["PYTHON_HISTORY"] = path
 
 
 def _enable_pretty_display() -> None:
@@ -66,7 +111,12 @@ def _set_colored_prompts() -> None:
         sys.ps2 = f"{brown}...{normal} "
 
 
-_enable_completion()
-_enable_history()
 _enable_pretty_display()
-_set_colored_prompts()
+
+if not _will_use_pyrepl():
+    _enable_completion()
+    _set_colored_prompts()
+    if sys.version_info < (3, 13):
+        _enable_history()
+    elif _is_libedit():
+        _redirect_history_for_libedit()

--- a/assets/python/pythonrc.py
+++ b/assets/python/pythonrc.py
@@ -57,14 +57,17 @@ def _enable_completion() -> None:
         readline.parse_and_bind("tab: complete")
 
 
+def _ensure_history_dir() -> None:
+    histdir = os.path.dirname(_history_base_path())
+    if histdir:
+        os.makedirs(histdir, exist_ok=True)
+
+
 def _enable_history() -> None:
     import atexit
     import readline
 
     histfile = _history_path()
-    histdir = os.path.dirname(histfile)
-    if histdir:
-        os.makedirs(histdir, exist_ok=True)
 
     if os.path.exists(histfile):
         try:
@@ -84,11 +87,7 @@ def _enable_history() -> None:
 
 
 def _redirect_history_for_libedit() -> None:
-    path = _history_path()
-    histdir = os.path.dirname(path)
-    if histdir:
-        os.makedirs(histdir, exist_ok=True)
-    os.environ["PYTHON_HISTORY"] = path
+    os.environ["PYTHON_HISTORY"] = _history_path()
 
 
 def _enable_pretty_display() -> None:
@@ -112,6 +111,7 @@ def _set_colored_prompts() -> None:
 
 
 _enable_pretty_display()
+_ensure_history_dir()
 
 if not _will_use_pyrepl():
     _enable_completion()

--- a/assets/shell/env.sh
+++ b/assets/shell/env.sh
@@ -46,6 +46,6 @@ if [ -z "${PYTHONSTARTUP:-}" ]; then
   export PYTHONSTARTUP="${XDG_CONFIG_HOME}/python/pythonrc.py"
 fi
 
-if [ -z "${PYTHONHISTFILE:-}" ]; then
-  export PYTHONHISTFILE="${XDG_STATE_HOME}/python/python_history"
+if [ -z "${PYTHON_HISTORY:-}" ]; then
+  export PYTHON_HISTORY="${XDG_STATE_HOME}/python/python_history"
 fi

--- a/tests/pty-driver.py
+++ b/tests/pty-driver.py
@@ -36,8 +36,6 @@ def main() -> None:
         os.execvp(argv[0], argv)
 
     _read_until(fd, b">>>")
-    os.write(fd, b"1+1\n")
-    _read_until(fd, b">>>")
     os.write(fd, b"exit()\n")
 
     while True:

--- a/tests/pty-driver.py
+++ b/tests/pty-driver.py
@@ -1,0 +1,58 @@
+"""Drive an interactive Python REPL under a PTY for testing."""
+
+from __future__ import annotations
+
+import os
+import pty
+import select
+import sys
+
+
+def _read_until(fd: int, marker: bytes, timeout: float = 10.0) -> bytes:
+    buf = b""
+    while True:
+        r, _, _ = select.select([fd], [], [], timeout)
+        if not r:
+            raise TimeoutError(f"timed out waiting for {marker!r}; captured: {buf!r}")
+        try:
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                break
+            buf += chunk
+            if marker in buf:
+                break
+        except OSError:
+            break
+    return buf
+
+
+def main() -> None:
+    argv = sys.argv[1:]
+    if not argv:
+        sys.exit("usage: pty-driver.py COMMAND [ARGS...]")
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.execvp(argv[0], argv)
+
+    _read_until(fd, b">>>")
+    os.write(fd, b"1+1\n")
+    _read_until(fd, b">>>")
+    os.write(fd, b"exit()\n")
+
+    while True:
+        r, _, _ = select.select([fd], [], [], 3)
+        if not r:
+            break
+        try:
+            if not os.read(fd, 4096):
+                break
+        except OSError:
+            break
+
+    _, status = os.waitpid(pid, 0)
+    sys.exit(os.waitstatus_to_exitcode(status))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-python.sh
+++ b/tests/test-python.sh
@@ -85,7 +85,7 @@ assert_python_startup_pyrepl_history() {
     uv run --no-project --python 3 python "${common_dir}/tests/pty-driver.py" "${python_exe}"
 
   test -f "${hist_dir}/history"
-  grep -q "1+1" "${hist_dir}/history"
+  grep -q "exit()" "${hist_dir}/history"
 
   if _is_libedit; then
     test ! -f "${hist_dir}/history.editline"
@@ -114,7 +114,7 @@ assert_python_startup_basic_repl_libedit_history() {
     uv run --no-project --python 3 python "${common_dir}/tests/pty-driver.py" "${python_exe}"
 
   test -f "${hist_dir}/history.editline"
-  grep -q "1+1" "${hist_dir}/history.editline"
+  grep -q "exit()" "${hist_dir}/history.editline"
   test ! -f "${hist_dir}/history"
 }
 

--- a/tests/test-python.sh
+++ b/tests/test-python.sh
@@ -12,6 +12,33 @@ issl_pythonrc_path="${issl_python_home}/pythonrc.py"
 # shellcheck source=tests/lib.sh
 source "${common_dir}/tests/lib.sh"
 
+_is_python_ge_3_13() {
+  local py_version major minor
+  py_version="$(uv run --no-project --python 3 python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+  IFS=. read -r major minor <<<"${py_version}"
+  [ "${major}" -gt 3 ] || { [ "${major}" -eq 3 ] && [ "${minor}" -ge 13 ]; }
+}
+
+_is_libedit() {
+  local result
+  result="$(uv run --no-project --python 3 python -c '
+import sys
+try:
+    import readline
+except ImportError:
+    print("no"); raise SystemExit
+if sys.version_info >= (3, 13):
+    print("yes" if getattr(readline, "backend", "") == "editline" else "no")
+else:
+    print("yes" if "libedit" in getattr(readline, "__doc__", "") else "no")
+')"
+  [ "${result}" = "yes" ]
+}
+
+_python_exe() {
+  uv run --no-project --python 3 python -c 'import sys; print(sys.executable)'
+}
+
 assert_uv_installation() {
   test -x "${nix_profile_bin}/uv"
   test "$(command -v uv)" = "${nix_profile_bin}/uv"
@@ -31,17 +58,64 @@ assert_python_startup_is_loaded() {
   local marker_dir
   marker_dir="$(mktemp -d)"
 
-  # Drive an interactive interpreter so PYTHONSTARTUP runs, then confirm it
-  # actually executed by observing the custom displayhook the startup installs.
   echo 'import sys; sys.exit(0 if sys.displayhook is not sys.__displayhook__ else 1)' |
     ISSL_PYTHON_HOME="${issl_python_home}" \
       PYTHONSTARTUP="${pythonrc_path}" \
-      PYTHONHISTFILE="${marker_dir}/history" \
+      PYTHON_HISTORY="${marker_dir}/history" \
       TERM=dumb \
       uv run --no-project --python 3 python -i
 
-  # The startup also wires up readline history persistence.
-  test -f "${marker_dir}/history"
+  test -f "${marker_dir}/history" || test -f "${marker_dir}/history.editline"
+}
+
+assert_python_startup_pyrepl_history() {
+  if ! _is_python_ge_3_13; then
+    echo "Skipping: Python < 3.13 (no pyrepl)"
+    return 0
+  fi
+
+  local hist_dir python_exe
+  hist_dir="$(mktemp -d)"
+  python_exe="$(_python_exe)"
+
+  ISSL_PYTHON_HOME="${issl_python_home}" \
+    PYTHONSTARTUP="${pythonrc_path}" \
+    PYTHON_HISTORY="${hist_dir}/history" \
+    TERM=xterm \
+    uv run --no-project --python 3 python "${common_dir}/tests/pty-driver.py" "${python_exe}"
+
+  test -f "${hist_dir}/history"
+  grep -q "1+1" "${hist_dir}/history"
+
+  if _is_libedit; then
+    test ! -f "${hist_dir}/history.editline"
+  fi
+}
+
+assert_python_startup_basic_repl_libedit_history() {
+  if ! _is_python_ge_3_13; then
+    echo "Skipping: Python < 3.13 (no basic REPL redirect needed)"
+    return 0
+  fi
+  if ! _is_libedit; then
+    echo "Skipping: readline backend is not libedit"
+    return 0
+  fi
+
+  local hist_dir python_exe
+  hist_dir="$(mktemp -d)"
+  python_exe="$(_python_exe)"
+
+  ISSL_PYTHON_HOME="${issl_python_home}" \
+    PYTHONSTARTUP="${pythonrc_path}" \
+    PYTHON_HISTORY="${hist_dir}/history" \
+    PYTHON_BASIC_REPL=1 \
+    TERM=xterm \
+    uv run --no-project --python 3 python "${common_dir}/tests/pty-driver.py" "${python_exe}"
+
+  test -f "${hist_dir}/history.editline"
+  grep -q "1+1" "${hist_dir}/history.editline"
+  test ! -f "${hist_dir}/history"
 }
 
 main() {
@@ -49,6 +123,8 @@ main() {
   run_assert assert_shared_pythonrc_asset
   run_assert assert_user_python_startup_file
   run_assert assert_python_startup_is_loaded
+  run_assert assert_python_startup_pyrepl_history
+  run_assert assert_python_startup_basic_repl_libedit_history
 }
 
 main "$@"

--- a/tests/test-python.sh
+++ b/tests/test-python.sh
@@ -74,21 +74,21 @@ assert_python_startup_pyrepl_history() {
     return 0
   fi
 
-  local hist_dir python_exe
-  hist_dir="$(mktemp -d)"
+  local hist_base python_exe
+  hist_base="$(mktemp -d)/state/python"
   python_exe="$(_python_exe)"
 
   ISSL_PYTHON_HOME="${issl_python_home}" \
     PYTHONSTARTUP="${pythonrc_path}" \
-    PYTHON_HISTORY="${hist_dir}/history" \
+    PYTHON_HISTORY="${hist_base}/history" \
     TERM=xterm \
     uv run --no-project --python 3 python "${common_dir}/tests/pty-driver.py" "${python_exe}"
 
-  test -f "${hist_dir}/history"
-  grep -q "exit()" "${hist_dir}/history"
+  test -f "${hist_base}/history"
+  grep -q "exit()" "${hist_base}/history"
 
   if _is_libedit; then
-    test ! -f "${hist_dir}/history.editline"
+    test ! -f "${hist_base}/history.editline"
   fi
 }
 
@@ -102,20 +102,20 @@ assert_python_startup_basic_repl_libedit_history() {
     return 0
   fi
 
-  local hist_dir python_exe
-  hist_dir="$(mktemp -d)"
+  local hist_base python_exe
+  hist_base="$(mktemp -d)/state/python"
   python_exe="$(_python_exe)"
 
   ISSL_PYTHON_HOME="${issl_python_home}" \
     PYTHONSTARTUP="${pythonrc_path}" \
-    PYTHON_HISTORY="${hist_dir}/history" \
+    PYTHON_HISTORY="${hist_base}/history" \
     PYTHON_BASIC_REPL=1 \
     TERM=xterm \
     uv run --no-project --python 3 python "${common_dir}/tests/pty-driver.py" "${python_exe}"
 
-  test -f "${hist_dir}/history.editline"
-  grep -q "exit()" "${hist_dir}/history.editline"
-  test ! -f "${hist_dir}/history"
+  test -f "${hist_base}/history.editline"
+  grep -q "exit()" "${hist_base}/history.editline"
+  test ! -f "${hist_base}/history"
 }
 
 main() {

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -32,7 +32,7 @@ test "${ISSL_PYTHON_HOME}" = "${XDG_CONFIG_HOME}/issl/python"
 test "${ISSL_RUST_HOME}" = "${XDG_CONFIG_HOME}/issl/rust"
 test "${CARGO_HOME}" = "${HOME}/.cargo"
 test "${PYTHONSTARTUP}" = "${XDG_CONFIG_HOME}/python/pythonrc.py"
-test "${PYTHONHISTFILE}" = "${XDG_STATE_HOME:-$HOME/.local/state}/python/python_history"
+test "${PYTHON_HISTORY}" = "${XDG_STATE_HOME:-$HOME/.local/state}/python/python_history"
 EOF
 }
 


### PR DESCRIPTION
- Branch pythonrc behavior by REPL type: displayhook always; completion/prompts only when pyrepl won't run; manual history only on < 3.13 (site hook handles >= 3.13)
- Separate history files by format to prevent corruption between GNU readline (plain) and libedit (`_HiStOrY_V2_`) writers — libedit writers use `.editline` suffix
- For >= 3.13 basic REPL with libedit, redirect the site hook by mutating `os.environ["PYTHON_HISTORY"]` in PYTHONSTARTUP (runs before the interactive hook)
- Replace the repo-local `PYTHONHISTFILE` convention with the official `PYTHON_HISTORY` env var
- Add PTY-based test driver and assertions for pyrepl history and the basic REPL + libedit redirect path

Closes #390
