### PR TITLE
fix(docker): make docker compose/buildx subcommands find CLI plugins

### DIFF
--- a/home-modules/docker.nix
+++ b/home-modules/docker.nix
@@ -1,20 +1,30 @@
 { pkgs, ... }:
 
 let
+  pluginDirs = "${pkgs.docker-compose}/libexec/docker/cli-plugins:${pkgs.docker-buildx}/libexec/docker/cli-plugins";
+
+  dockerClient = pkgs.symlinkJoin {
+    name = "docker-client";
+    paths = [ pkgs.docker-client ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram "$out/bin/docker" --prefix DOCKER_CLI_PLUGIN_DIRS : "${pluginDirs}"
+    '';
+  };
+
   dockerCompose = pkgs.symlinkJoin {
     name = "docker-compose";
     paths = [ pkgs.docker-compose ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
-      wrapProgram "$out/bin/docker-compose" \
-        --prefix DOCKER_CLI_PLUGIN_DIRS : "${pkgs.docker-compose}/libexec/docker/cli-plugins:${pkgs.docker-buildx}/libexec/docker/cli-plugins"
+      wrapProgram "$out/bin/docker-compose" --prefix DOCKER_CLI_PLUGIN_DIRS : "${pluginDirs}"
     '';
   };
 in
 {
   home.packages = [
-    pkgs.docker-client
-    pkgs.docker-buildx
+    dockerClient
     dockerCompose
+    pkgs.docker-buildx
   ];
 }

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -330,7 +330,7 @@ install_docker_engine() {
     sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
 
   sudo apt-get update
-  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  sudo apt-get install -y --no-install-recommends docker-ce docker-ce-cli containerd.io pigz
 
   if should_add_user_to_docker_group; then
     docker_user="$(target_docker_user)"

--- a/tests/test-docker.sh
+++ b/tests/test-docker.sh
@@ -14,10 +14,16 @@ assert_docker_client_installation() {
   docker --version
 }
 
+assert_docker_client_plugin_dirs_wrapper() {
+  grep -Fq "DOCKER_CLI_PLUGIN_DIRS" "${nix_profile_bin}/docker"
+  grep -Fq "docker-buildx" "${nix_profile_bin}/docker"
+}
+
 assert_docker_compose_installation() {
   test -x "${nix_profile_bin}/docker-compose"
   test "$(command -v docker-compose)" = "${nix_profile_bin}/docker-compose"
   docker-compose version
+  docker compose version
 }
 
 assert_docker_compose_plugin_dirs_wrapper() {
@@ -29,10 +35,12 @@ assert_docker_buildx_installation() {
   test -x "${nix_profile_bin}/docker-buildx"
   test "$(command -v docker-buildx)" = "${nix_profile_bin}/docker-buildx"
   docker-buildx version
+  docker buildx version
 }
 
 main() {
   run_assert assert_docker_client_installation
+  run_assert assert_docker_client_plugin_dirs_wrapper
   run_assert assert_docker_compose_installation
   run_assert assert_docker_compose_plugin_dirs_wrapper
   run_assert assert_docker_buildx_installation


### PR DESCRIPTION
The `docker compose` / `docker buildx` subcommand forms did not work because the nixpkgs-patched Docker CLI searches system plugin directories only via `DOCKER_CLI_PLUGIN_DIRS`, which was set only for the standalone `docker-compose` wrapper.

- Wrap the docker client in `home-modules/docker.nix` with `DOCKER_CLI_PLUGIN_DIRS` pointing at the Nix-built buildx/compose plugin directories, reusing the existing `docker-compose` wrapper pattern.
- Minimize the Docker Engine apt install in `scripts/bootstrap-host.sh` to `--no-install-recommends docker-ce docker-ce-cli containerd.io pigz`; the CLI plugins are provided via Home Manager, and `pigz` is kept because `dockerd` consumes it in the root context.
- Add test assertions for the docker client wrapper and the `docker compose version` / `docker buildx version` subcommand forms.

As noted in the issue, `sudo docker compose` / `sudo docker buildx` are out of scope, and the bootstrap change should be verified once on a clean VM since the Docker Engine install path is not covered by CI (#337).

Closes #388
