### PR TITLE
fix(apply): preserve file permissions in prepend_block_once

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -47,7 +47,7 @@ prepend_block_once() {
   fi
 
   local original_mode=""
-  original_mode="$(stat -c %a "${file_path}")"
+  original_mode="$(stat -L -c %a "${file_path}")"
 
   temp_file="$(mktemp)"
   {

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -46,6 +46,9 @@ prepend_block_once() {
     return
   fi
 
+  local original_mode=""
+  original_mode="$(stat -c %a "${file_path}")"
+
   temp_file="$(mktemp)"
   {
     printf '%s\n' "${begin_marker}"
@@ -56,6 +59,7 @@ prepend_block_once() {
       cat "${file_path}"
     fi
   } >"${temp_file}"
+  chmod "${original_mode}" "${temp_file}"
   mv "${temp_file}" "${file_path}"
 }
 

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -59,8 +59,8 @@ prepend_block_once() {
       cat "${file_path}"
     fi
   } >"${temp_file}"
-  chmod "${original_mode}" "${temp_file}"
   mv "${temp_file}" "${file_path}"
+  chmod "${original_mode}" "${file_path}"
 }
 
 is_yes() {


### PR DESCRIPTION
`prepend_block_once` uses `mktemp` (mode 600) followed by `mv`, which silently replaces the original file's permissions with 600.
This preserves the original mode by capturing it with `stat -c %a` before writing the temp file and applying `chmod` before the `mv`.

Closes #391
