### PR TITLE
fix(setup): clean up temporary bootstrap file after download

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -129,12 +129,15 @@ load_bootstrap_host() {
   fi
 
   temporary_bootstrap="$(mktemp)"
+  trap 'rm -f "${temporary_bootstrap}"' EXIT
   while IFS= read -r bootstrap_url; do
     [ -n "${bootstrap_url}" ] || continue
 
     if curl -fsSL "${bootstrap_url}" -o "${temporary_bootstrap}"; then
       # shellcheck source=/dev/null
       . "${temporary_bootstrap}"
+      rm -f "${temporary_bootstrap}"
+      trap - EXIT
       return
     fi
   done <<<"${bootstrap_urls}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -129,7 +129,8 @@ load_bootstrap_host() {
   fi
 
   temporary_bootstrap="$(mktemp)"
-  trap 'rm -f "${temporary_bootstrap}"' EXIT
+  # shellcheck disable=SC2064
+  trap "rm -f '${temporary_bootstrap}'" EXIT
   while IFS= read -r bootstrap_url; do
     [ -n "${bootstrap_url}" ] || continue
 
@@ -137,7 +138,6 @@ load_bootstrap_host() {
       # shellcheck source=/dev/null
       . "${temporary_bootstrap}"
       rm -f "${temporary_bootstrap}"
-      trap - EXIT
       return
     fi
   done <<<"${bootstrap_urls}"


### PR DESCRIPTION
- `load_bootstrap_host` downloads `bootstrap-host.sh` into a `mktemp` file but never removes it
- Add `trap 'rm -f ...' EXIT` right after `mktemp` so the file is cleaned up on any exit path
- On the success path, explicitly `rm -f` and clear the trap before returning

Closes #393
