### PR TITLE
fix(bootstrap): skip SSH registration prompt in non-interactive mode

### DIFF
--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -237,6 +237,13 @@ prompt_github_ssh_setup() {
   fi
 
   ensure_github_ssh_config
+
+  if ! is_interactive; then
+    echo "Register the following public key in GitHub and re-run:" >&2
+    echo "  ${github_key_path}.pub" >&2
+    return
+  fi
+
   prompt_github_ssh_registration
 }
 


### PR DESCRIPTION
- When an SSH key exists but isn't registered with GitHub, `prompt_github_ssh_setup` falls through to `prompt_github_ssh_registration` in non-interactive mode, causing `exit 1` with a confusing message
- Add a non-interactive guard before the registration prompt that prints the public key path and returns, letting the caller (`try_github_ssh_recovery`) continue its own error handling

Closes #392
