### PR TITLE
fix(shell): replace deprecated egrep/fgrep with grep -E/-F

### DIFF
--- a/assets/shell/rc.sh
+++ b/assets/shell/rc.sh
@@ -27,12 +27,12 @@ if command -v dircolors >/dev/null 2>&1; then
     eval "$(dircolors -b)"
   fi
 
-  alias ls='ls --color=auto'       # Colorize directory listings.
-  alias dir='dir --color=auto'     # Colorize dir output.
-  alias vdir='vdir --color=auto'   # Colorize verbose dir output.
-  alias grep='grep --color=auto'   # Highlight grep matches.
-  alias fgrep='fgrep --color=auto' # Highlight fixed-string grep matches.
-  alias egrep='egrep --color=auto' # Highlight extended-regex grep matches.
+  alias ls='ls --color=auto'         # Colorize directory listings.
+  alias dir='dir --color=auto'       # Colorize dir output.
+  alias vdir='vdir --color=auto'     # Colorize verbose dir output.
+  alias grep='grep --color=auto'     # Highlight grep matches.
+  alias fgrep='grep -F --color=auto' # Highlight fixed-string grep matches.
+  alias egrep='grep -E --color=auto' # Highlight extended-regex grep matches.
 fi
 
 alias rm='rm -i' # Ask before file removal.


### PR DESCRIPTION
- Replace deprecated `egrep`/`fgrep` aliases with `grep -E`/`grep -F` in `assets/shell/rc.sh`
- Users who type `fgrep` or `egrep` still get the expected behavior via the alias

Closes #394
