### PR TITLE
ci: run setup.sh end-to-end in the script-based test

### DIFF
--- a/.github/workflows/test-environment.yaml
+++ b/.github/workflows/test-environment.yaml
@@ -6,6 +6,10 @@ on:
       setup-mode:
         required: true
         type: string
+      entry-point:
+        required: false
+        type: string
+        default: apply
       os:
         required: false
         type: string
@@ -75,6 +79,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
+        if: ${{ !(inputs.setup-mode == 'script-based' && inputs.entry-point == 'setup') }}
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +103,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run apply.sh
-        if: inputs.setup-mode == 'script-based'
+        if: inputs.setup-mode == 'script-based' && inputs.entry-point == 'apply'
         shell: bash
         env:
           HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
@@ -116,6 +121,31 @@ jobs:
             GIT_USER_NAME="ISSL Test User" \
             GIT_USER_EMAIL="issl-test@example.com" \
             bash ./common/scripts/apply.sh
+
+      - name: Run setup.sh
+        if: inputs.setup-mode == 'script-based' && inputs.entry-point == 'setup'
+        shell: bash
+        env:
+          HOME_DIR: ${{ steps.test-env.outputs.home_dir }}
+          CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
+          DATA_DIR: ${{ steps.test-env.outputs.data_dir }}
+          STATE_DIR: ${{ steps.test-env.outputs.state_dir }}
+        run: |
+          git -C common branch ci-setup-entry HEAD
+
+          env \
+            HOME="${HOME_DIR}" \
+            USER="issl-test" \
+            XDG_CONFIG_HOME="${CONFIG_DIR}" \
+            XDG_DATA_HOME="${DATA_DIR}" \
+            XDG_STATE_HOME="${STATE_DIR}" \
+            REPO_URL="file://${GITHUB_WORKSPACE}/common" \
+            REPO_REF="ci-setup-entry" \
+            ISSL_INSTALL_DOCKER=no \
+            ISSL_ENABLE_ZSH="${{ matrix.enable_zsh }}" \
+            GIT_USER_NAME="ISSL Test User" \
+            GIT_USER_EMAIL="issl-test@example.com" \
+            bash ./common/scripts/setup.sh
 
       - name: Apply Home Manager configuration
         if: inputs.setup-mode == 'repository-based'

--- a/.github/workflows/test-environment.yaml
+++ b/.github/workflows/test-environment.yaml
@@ -130,6 +130,7 @@ jobs:
           CONFIG_DIR: ${{ steps.test-env.outputs.config_dir }}
           DATA_DIR: ${{ steps.test-env.outputs.data_dir }}
           STATE_DIR: ${{ steps.test-env.outputs.state_dir }}
+          NIX_CONFIG: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
         run: |
           git -C common branch ci-setup-entry HEAD
 
@@ -146,6 +147,8 @@ jobs:
             GIT_USER_NAME="ISSL Test User" \
             GIT_USER_EMAIL="issl-test@example.com" \
             bash ./common/scripts/setup.sh
+
+          echo "/nix/var/nix/profiles/default/bin" >>"${GITHUB_PATH}"
 
       - name: Apply Home Manager configuration
         if: inputs.setup-mode == 'repository-based'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ on:
       - flake.lock
       - home-modules/**
       - scripts/apply.sh
+      - scripts/bootstrap-host.sh
+      - scripts/setup.sh
       - tests/**
   pull_request:
     types: [opened, synchronize, reopened]
@@ -23,6 +25,8 @@ on:
       - flake.lock
       - home-modules/**
       - scripts/apply.sh
+      - scripts/bootstrap-host.sh
+      - scripts/setup.sh
       - tests/**
 
 concurrency:
@@ -42,12 +46,17 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-26.04
+        entry-point:
+          - apply
+          - setup
     uses: ./.github/workflows/test-environment.yaml
     with:
       setup-mode: script-based
+      entry-point: ${{ matrix.entry-point }}
       os: ${{ matrix.os }}
       common-repository: ${{ github.repository }}
       common-ref: ${{ github.sha }}
+      timeout-minutes: 15
 
   repository-based:
     name: Test config-repository-based setup
@@ -67,3 +76,4 @@ jobs:
       user-repository: ut-issl/personal-nix-config-template
       user-ref: 710819df83c6984834f82ae9dde7603a00416ef8 # main
       override-issl-input: true
+      timeout-minutes: 15


### PR DESCRIPTION
- Add an `entry-point` axis (`apply` / `setup`) to the script-based test job.
  The `apply` leg keeps the current behavior of running `apply.sh` with a pre-installed Nix, while the new `setup` leg runs `scripts/setup.sh` end-to-end: it installs Nix itself, clones the repository from a local `file://` remote at the tested commit, applies the configuration, and then reuses the existing environment tests.
- Expose the default Nix profile bin directory to later steps via `GITHUB_PATH`, and pass a GitHub access token through `NIX_CONFIG` so flake fetches are not rate-limited on shared runner IPs.
- Add `scripts/setup.sh` and `scripts/bootstrap-host.sh` to the workflow path filters, and raise the job timeout to cover the Nix installation.

Closes #337
