### PR TITLE
fix(scripts): guard apply.sh against Home Manager-managed environments

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -91,11 +91,17 @@ prepend_block_once() {
 
   file_dir="$(dirname "${file_path}")"
   mkdir -p "${file_dir}"
-  touch "${file_path}"
 
-  if grep -Fq "${begin_marker}" "${file_path}"; then
+  if [ -f "${file_path}" ] && grep -Fq "${begin_marker}" "${file_path}"; then
     return
   fi
+
+  if is_nix_store_symlink "${file_path}"; then
+    echo "error: refusing to modify ${file_path} because it is a symlink into the Nix store (likely managed by Home Manager)." >&2
+    exit 1
+  fi
+
+  touch "${file_path}"
 
   local original_mode=""
   original_mode="$(stat -L -c %a "${file_path}")"

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -279,7 +279,7 @@ resolve_zdotdir_from_zshenv() {
         if [ -n "${ZDOTDIR:-}" ]; then
           print -r -- "${ZDOTDIR:A}"
         fi
-      ' _ "${zshenv_path}"
+      ' _ "${zshenv_path}" </dev/null
   )"
   [ -n "${resolved_value}" ] || return 1
   printf '%s\n' "${resolved_value}"

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -44,8 +44,16 @@ resolves_into_nix_store() {
 guard_against_existing_home_manager_files() {
   local zdotdir_path="${ZDOTDIR:-${XDG_CONFIG_HOME}/zsh}"
   local cargo_home_path="${CARGO_HOME:-$HOME/.cargo}"
+  local zshenv_path="${HOME}/.zshenv"
+  local resolved_zdotdir=""
   local candidate_path=""
   local managed_paths=()
+
+  if zshenv_defines_zdotdir "${zshenv_path}" &&
+    resolved_zdotdir="$(resolve_zdotdir_from_zshenv "${zshenv_path}")"; then
+    zdotdir_path="${resolved_zdotdir}"
+  fi
+
   local candidate_paths=(
     "${XDG_CONFIG_HOME}/nix/nix.conf"
     "${HOME}/.profile"
@@ -235,6 +243,12 @@ should_enable_zsh() {
   is_yes "${response}"
 }
 
+zshenv_defines_zdotdir() {
+  local zshenv_path="$1"
+
+  [ -f "${zshenv_path}" ] && grep -Eq '^[[:space:]]*(export[[:space:]]+)?ZDOTDIR[[:space:]]*=' "${zshenv_path}"
+}
+
 resolve_zdotdir_from_zshenv() {
   local zshenv_path="$1"
   local zsh_bin=""
@@ -292,7 +306,7 @@ ensure_zsh_startup_files() {
   local zshenv_path="${HOME}/.zshenv"
   local zdotdir_path=""
 
-  if [ -f "${zshenv_path}" ] && grep -Eq '^[[:space:]]*(export[[:space:]]+)?ZDOTDIR[[:space:]]*=' "${zshenv_path}"; then
+  if zshenv_defines_zdotdir "${zshenv_path}"; then
     if ! zdotdir_path="$(resolve_zdotdir_from_zshenv "${zshenv_path}")"; then
       echo "Could not determine ZDOTDIR from ${zshenv_path}." >&2
       exit 1

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -53,8 +53,9 @@ guard_against_existing_home_manager_files() {
   if zshenv_defines_zdotdir "${zshenv_path}"; then
     if resolved_zdotdir="$(resolve_zdotdir_from_zshenv "${zshenv_path}")"; then
       zdotdir_path="${resolved_zdotdir}"
-    elif [ "${zsh_enabled}" = "1" ]; then
-      echo "Could not determine ZDOTDIR from ${zshenv_path}." >&2
+    elif [ "${zsh_enabled}" = "1" ] && resolve_zsh_bin >/dev/null; then
+      echo "error: ${zshenv_path} defines ZDOTDIR, but it could not be resolved before the Home Manager switch." >&2
+      echo "Fix ${zshenv_path} so that zsh can evaluate it, or re-run with ISSL_ENABLE_ZSH=no to skip the zsh setup." >&2
       exit 1
     fi
   fi

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -30,6 +30,57 @@ ensure_home_manager_profile_dir() {
   mkdir -p "${hm_profile_dir}"
 }
 
+is_nix_store_symlink() {
+  local path="$1"
+  local resolved_path=""
+
+  [ -L "${path}" ] || return 1
+  resolved_path="$(readlink -f "${path}")" || return 1
+  case "${resolved_path}" in
+  /nix/store/*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+guard_against_existing_home_manager_files() {
+  local zdotdir_path="${ZDOTDIR:-${XDG_CONFIG_HOME}/zsh}"
+  local cargo_home_path="${CARGO_HOME:-$HOME/.cargo}"
+  local candidate_path=""
+  local managed_paths=()
+  local candidate_paths=(
+    "${XDG_CONFIG_HOME}/nix/nix.conf"
+    "${HOME}/.profile"
+    "${HOME}/.bash_profile"
+    "${HOME}/.bashrc"
+    "${HOME}/.zshenv"
+    "${zdotdir_path}/.zprofile"
+    "${zdotdir_path}/.zshrc"
+    "${HOME}/.gitconfig"
+    "${XDG_CONFIG_HOME}/git/config"
+    "${XDG_CONFIG_HOME}/python/pythonrc.py"
+    "${cargo_home_path}/config.toml"
+  )
+
+  for candidate_path in "${candidate_paths[@]}"; do
+    if is_nix_store_symlink "${candidate_path}"; then
+      managed_paths+=("${candidate_path}")
+    fi
+  done
+
+  if [ "${#managed_paths[@]}" -eq 0 ]; then
+    return
+  fi
+
+  {
+    echo "error: the following files are symlinks into the Nix store, so this machine already appears to be managed by an existing Home Manager configuration:"
+    printf '  %s\n' "${managed_paths[@]}"
+    echo "Running the script-based setup here would replace that configuration's Home Manager profile and detach these files from its control."
+    echo "Keep managing this machine with your existing Home Manager configuration (e.g. your personal config repository) instead."
+    echo "If you really want to switch to the script-based setup, remove the existing Home Manager configuration first and re-run this script."
+  } >&2
+  exit 1
+}
+
 prepend_block_once() {
   local file_path="$1"
   local begin_marker="$2"
@@ -533,6 +584,8 @@ main() {
     echo "nix is required before running scripts/apply.sh." >&2
     exit 1
   fi
+
+  guard_against_existing_home_manager_files
 
   if [ -n "${NIX_CONFIG-}" ]; then
     export NIX_CONFIG="${NIX_CONFIG}"$'\n'"${nix_feature_config}"

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -30,12 +30,11 @@ ensure_home_manager_profile_dir() {
   mkdir -p "${hm_profile_dir}"
 }
 
-is_nix_store_symlink() {
+resolves_into_nix_store() {
   local path="$1"
   local resolved_path=""
 
-  [ -L "${path}" ] || return 1
-  resolved_path="$(readlink -f "${path}")" || return 1
+  resolved_path="$(readlink -m "${path}")" || return 1
   case "${resolved_path}" in
   /nix/store/*) return 0 ;;
   *) return 1 ;;
@@ -62,7 +61,7 @@ guard_against_existing_home_manager_files() {
   )
 
   for candidate_path in "${candidate_paths[@]}"; do
-    if is_nix_store_symlink "${candidate_path}"; then
+    if resolves_into_nix_store "${candidate_path}"; then
       managed_paths+=("${candidate_path}")
     fi
   done
@@ -72,7 +71,7 @@ guard_against_existing_home_manager_files() {
   fi
 
   {
-    echo "error: the following files are symlinks into the Nix store, so this machine already appears to be managed by an existing Home Manager configuration:"
+    echo "error: the following files resolve into the Nix store, so this machine already appears to be managed by an existing Home Manager configuration:"
     printf '  %s\n' "${managed_paths[@]}"
     echo "Running the script-based setup here would replace that configuration's Home Manager profile and detach these files from its control."
     echo "Keep managing this machine with your existing Home Manager configuration (e.g. your personal config repository) instead."
@@ -96,8 +95,8 @@ prepend_block_once() {
     return
   fi
 
-  if is_nix_store_symlink "${file_path}"; then
-    echo "error: refusing to modify ${file_path} because it is a symlink into the Nix store (likely managed by Home Manager)." >&2
+  if resolves_into_nix_store "${file_path}"; then
+    echo "error: refusing to modify ${file_path} because it resolves into the Nix store (likely managed by Home Manager)." >&2
     exit 1
   fi
 

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -42,16 +42,21 @@ resolves_into_nix_store() {
 }
 
 guard_against_existing_home_manager_files() {
-  local zdotdir_path="${ZDOTDIR:-${XDG_CONFIG_HOME}/zsh}"
+  local zsh_enabled="$1"
+  local zdotdir_path="${XDG_CONFIG_HOME}/zsh"
   local cargo_home_path="${CARGO_HOME:-$HOME/.cargo}"
   local zshenv_path="${HOME}/.zshenv"
   local resolved_zdotdir=""
   local candidate_path=""
   local managed_paths=()
 
-  if zshenv_defines_zdotdir "${zshenv_path}" &&
-    resolved_zdotdir="$(resolve_zdotdir_from_zshenv "${zshenv_path}")"; then
-    zdotdir_path="${resolved_zdotdir}"
+  if zshenv_defines_zdotdir "${zshenv_path}"; then
+    if resolved_zdotdir="$(resolve_zdotdir_from_zshenv "${zshenv_path}")"; then
+      zdotdir_path="${resolved_zdotdir}"
+    elif [ "${zsh_enabled}" = "1" ]; then
+      echo "Could not determine ZDOTDIR from ${zshenv_path}." >&2
+      exit 1
+    fi
   fi
 
   local candidate_paths=(
@@ -604,7 +609,13 @@ main() {
     exit 1
   fi
 
-  guard_against_existing_home_manager_files
+  if should_enable_zsh; then
+    zsh_enabled=1
+  else
+    zsh_enabled=0
+  fi
+
+  guard_against_existing_home_manager_files "${zsh_enabled}"
 
   if [ -n "${NIX_CONFIG-}" ]; then
     export NIX_CONFIG="${NIX_CONFIG}"$'\n'"${nix_feature_config}"
@@ -620,12 +631,10 @@ main() {
   )"
 
   ensure_home_manager_profile_dir
-  if should_enable_zsh; then
+  if [ "${zsh_enabled}" = "1" ]; then
     home_configuration_name="issl-common-zsh-${current_system}"
-    zsh_enabled=1
   else
     home_configuration_name="issl-common-${current_system}"
-    zsh_enabled=0
   fi
 
   if [ "${zsh_enabled}" = "0" ]; then


### PR DESCRIPTION
Running the script-based setup on a machine already managed by an existing Home Manager configuration silently corrupted that setup: the `home-manager switch` step replaced the existing profile generation and removed its managed dotfiles, and `prepend_block_once` then recreated them as plain files.

- Add a pre-flight guard that inspects every file `apply.sh` would mutate and aborts with an explanatory message before the switch when any of them resolves into the Nix store.
- Resolve full paths with `readlink -m` so symlinked parent directories and dangling store symlinks are also detected.
- Resolve a custom `ZDOTDIR` from `~/.zshenv` the same way as the later zsh wiring; when zsh wiring is enabled and a zsh binary is available but resolution fails, abort before the switch, and fall back to the default candidates when zsh is not installed yet.
- As defense in depth, make `prepend_block_once` refuse to rewrite a target that resolves into the Nix store, covering dynamically resolved paths.

A known limitation is documented in the issue: a Home Manager configuration that manages none of the inspected files still gets its profile generation replaced by the switch, since there is no reliable way to attribute the existing profile to its owning configuration.

Closes #332
