### PR TITLE
feat(nix): allow unfree packages

### DIFF
--- a/docs/12-script-based-setup.md
+++ b/docs/12-script-based-setup.md
@@ -103,3 +103,12 @@ Upgrade installed profile packages:
 ```bash
 nix profile upgrade --all
 ```
+
+`nix profile` refuses packages with an unfree license, even though the shared Home Manager configuration allows them.
+Allow it for every invocation that evaluates such a package, including a later `nix profile upgrade`:
+
+```bash
+NIXPKGS_ALLOW_UNFREE=1 nix profile install --impure nixpkgs#claude-code
+```
+
+See [package management practices](13-package-management-practices.md#unfree-packages).

--- a/docs/13-package-management-practices.md
+++ b/docs/13-package-management-practices.md
@@ -15,6 +15,18 @@ Use Nix with Home Manager for tools that should be available across your user en
 - For a personal reproducible setup, see [setup with a personal config repository](11-setup-with-a-personal-config-repository.md).
 - For the script-based setup workflow, see [script-based setup](12-script-based-setup.md#if-you-need-additional-tools-or-settings).
 
+### Unfree Packages
+
+This environment sets `nixpkgs.config.allowUnfree = true`, so packages with an unfree license install without extra setup.
+This applies both to the shared packages of this repository
+and to the packages you add in a personal config repository that imports it.
+
+Installing such a package means accepting its license, which is not the same as the license of this repository.
+Check the terms of the package before you install it, and before you propose adding one to the shared environment.
+
+The setting only covers Home Manager.
+`nix profile` evaluates Nixpkgs on its own and still refuses unfree packages, as described in [script-based setup](12-script-based-setup.md#3-if-it-is-personal-and-reproducibility-is-not-necessary).
+
 ## 2. Project-Local Dependencies
 
 Use project-local package managers for dependencies that belong to a specific repository.

--- a/docs/92-updating-or-adding-an-asset-or-module.md
+++ b/docs/92-updating-or-adding-an-asset-or-module.md
@@ -61,6 +61,11 @@ For example:
 }
 ```
 
+`home-modules/nix.nix` sets `nixpkgs.config.allowUnfree = true` for the whole configuration,
+so a module may add a package with an unfree license.
+Because that setting also applies to everyone who imports this repository,
+state in the pull request why the package is worth distributing to all users under its license terms.
+
 When updating or adding a module:
 
 1. Update an existing file under `home-modules/`, or create a new one if needed.

--- a/home-modules/nix.nix
+++ b/home-modules/nix.nix
@@ -1,6 +1,8 @@
 _:
 
 {
+  nixpkgs.config.allowUnfree = true;
+
   xdg.configFile."issl/nix/nix.conf".source = ../assets/nix/nix.conf;
 
   programs.home-manager.enable = true;


### PR DESCRIPTION
- Set `nixpkgs.config.allowUnfree = true` in `home-modules/nix.nix` so this repository can distribute packages with an unfree license.
- Home Manager builds its package set from `nixpkgs.config` rather than from the `pkgs` it is given, so the setting also applies to personal configuration repositories that import this one, without each of them having to set it.
- Document the setting and its license implications in the user and developer docs, including the fact that `nix profile` evaluates Nixpkgs on its own and is not covered by it.
