### PR TITLE
feat: add develop skill for shared environment changes

### DIFF
--- a/.agents/skills/develop/SKILL.md
+++ b/.agents/skills/develop/SKILL.md
@@ -149,20 +149,11 @@ Run validation in this order:
 
 1. Run `prek run --files <changed files> --skip no-commit-to-branch` and fix what it reports.
    If `prek` is not on PATH, use `uvx prek` instead.
-2. Run `nix flake check --show-trace`.
-   This builds the activation packages for both the Bash-only and the Zsh configuration,
-   and catches Nix evaluation errors and build failures.
-3. Build the activation packages to inspect the installed binaries and deployed files:
-
-   ```console
-   nix build .#checks.x86_64-linux.home --out-link result-home
-   nix build .#checks.x86_64-linux.home-zsh --out-link result-home-zsh
-   ```
-
+2. Run the Nix validation of `docs/92-updating-or-adding-an-asset-or-module.md` § "Validating Changes":
+   stage the new files, run the flake checks,
+   then build the activation packages and inspect the installed binaries and deployed files.
+   Build for the system of this machine, not the one in the example command.
    Remove the `result-*` symlinks when done.
-
-See `docs/92-updating-or-adding-an-asset-or-module.md` § "Validating Changes"
-for what the build result contains and how to inspect it.
 
 ## 8. Wrap up
 

--- a/.agents/skills/develop/SKILL.md
+++ b/.agents/skills/develop/SKILL.md
@@ -114,7 +114,8 @@ Every module should have corresponding test coverage under `tests/`.
 Tests run in CI against a freshly applied environment
 (`.github/workflows/test-environment.yaml` sets `HOME_DIR`/`CONFIG_DIR` and runs `tests/run.sh`).
 Do not try to run them locally unless this machine has the shared environment applied;
-local validation is prek plus `nix flake check` (step 7).
+local validation is prek plus the Nix validation in step 7,
+which can confirm installed binaries and deployed files without applying anything.
 
 If a test file for this area already exists (e.g. `tests/test-<tool>.sh`), extend it.
 If not, create a new `tests/test-<tool>.sh` following the existing pattern:
@@ -148,8 +149,20 @@ Run validation in this order:
 
 1. Run `prek run --files <changed files> --skip no-commit-to-branch` and fix what it reports.
    If `prek` is not on PATH, use `uvx prek` instead.
-2. With Nix, run `nix flake check --show-trace`.
-   This builds the activation packages and catches both Nix evaluation errors and build failures.
+2. Run `nix flake check --show-trace`.
+   This builds the activation packages for both the Bash-only and the Zsh configuration,
+   and catches Nix evaluation errors and build failures.
+3. Build the activation packages to inspect the installed binaries and deployed files:
+
+   ```console
+   nix build .#checks.x86_64-linux.home --out-link result-home
+   nix build .#checks.x86_64-linux.home-zsh --out-link result-home-zsh
+   ```
+
+   Remove the `result-*` symlinks when done.
+
+See `docs/92-updating-or-adding-an-asset-or-module.md` § "Validating Changes"
+for what the build result contains and how to inspect it.
 
 ## 8. Wrap up
 

--- a/.agents/skills/develop/SKILL.md
+++ b/.agents/skills/develop/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: develop
+description: >-
+  Guide development of the shared ISSL environment:
+  adding or updating tools, modules, assets, and tests.
+  Use when asked to add a tool or package to the shared environment,
+  update an existing module or asset, or modify how the environment is configured.
+  Do not use for documentation-only changes, CI/CD pipeline changes,
+  or dependency version bumps handled by Renovate.
+---
+
+# Develop the Shared Environment
+
+Help update or extend the shared ISSL Ubuntu environment, one change at a time:
+add a tool, update a module, add or modify an asset, or adjust the imperative setup.
+
+Follow the conventions in `docs/92-updating-or-adding-an-asset-or-module.md`
+and `docs/93-contribution-guidelines.md`.
+Converse in the language the user writes in, but keep all edits (code, comments, commit messages, etc.) in English.
+Leave all changes uncommitted; committing and pushing are up to the user unless explicitly requested.
+Never write secrets (tokens, private keys, credentials) into the repository;
+assets in this repository are deployed to every lab machine.
+Never run `scripts/apply.sh`, `scripts/setup.sh`, or `home-manager switch`
+against the user's real home environment without explicit approval;
+use prek and `nix flake check` for local validation instead.
+
+Before starting, verify that `nix` is available (`command -v nix`).
+Nix is required for developing this repository;
+changes cannot be validated without it, and bugs here affect the entire lab.
+If Nix is not available, stop and ask the user to set it up first.
+
+## 1. Understand the request
+
+Identify what the user wants: a new tool in the shared environment,
+a change to an existing tool's configuration, a new asset, or a structural change.
+Ask only if the request is ambiguous.
+
+## 2. Check what already exists
+
+Before adding anything, scan the actual repository state (not the docs, which may lag):
+
+- `home-modules/` for existing modules that already cover the tool or area.
+- `home-modules/main.nix` imports to understand how modules are organized
+  and whether they are unconditional or conditional (e.g. `lib.optional enableZsh`).
+- `assets/` for existing configuration files.
+- `tests/` for existing test coverage.
+- `scripts/apply.sh` for existing imperative wiring.
+
+If there is already a related module or asset, update it rather than creating a new one.
+
+## 3. Research the package and its options
+
+For a new tool:
+
+- Look the package up in nixpkgs at the pinned revision:
+  read the `nixpkgs` entry's `locked.rev` from `flake.lock`
+  and run `nix search github:NixOS/nixpkgs/<rev> <name>`.
+- Check whether Home Manager has a matching module (`programs.<tool>` or `services.<tool>`)
+  to understand available options — but see step 4 for why this repo does not use them directly.
+  On a machine with the environment applied,
+  `man home-configuration.nix` documents the installed version and is the source of truth;
+  otherwise use the Home Manager manual for the matching release.
+- Unfree packages are not enabled in this flake.
+  Adding one requires a flake change and an explicit yes from the user.
+- If the package is not in nixpkgs, report honestly and let the user decide.
+  Never add flake inputs or overlays without an explicit yes.
+
+## 4. Decide where the change goes
+
+Follow the conventions in `docs/92-updating-or-adding-an-asset-or-module.md`.
+
+This repository deliberately does not use Home Manager's `programs.<tool>` options
+that generate user-level config files (e.g. `~/.gitconfig`, `~/.bashrc`).
+Shared configuration is deployed under `~/.config/issl/` and included or sourced from user-managed files instead,
+to preserve user flexibility and avoid conflicts with both setup modes.
+
+- **Existing module covers this area**: update that module.
+- **New tool with no settings**: add to `home.packages` in an existing module
+  that covers the same area, or create a new module if it represents a distinct area.
+- **New tool with shared configuration**: create a dedicated module `home-modules/<tool>.nix`
+  and place the config file under `assets/<tool>/`.
+  Use `xdg.configFile."issl/<tool>/..."` to deploy shared configuration
+  under the ISSL config directory,
+  or `home.file` when the config must live at a fixed path outside `~/.config/issl/`.
+- **New module**: import it from `home-modules/main.nix`.
+  Add it conditionally with `lib.optional` if it should only be enabled
+  in specific configurations, following the pattern of `zsh.nix`.
+  Reuse the existing `enableZsh` flag where it fits;
+  introducing a new condition also requires changes to `flake.nix`
+  (`extraSpecialArgs`, configurations, checks) and the CI test matrix —
+  confirm with the user before going that route.
+
+If the change also requires imperative wiring
+(connecting shared config to user-managed files such as `~/.bashrc` or `~/.cargo/config.toml`),
+`scripts/apply.sh` will need updating as well.
+But prefer declarative integration in `home-modules/` first,
+and update `scripts/apply.sh` only when that is not enough.
+See `docs/92-updating-or-adding-an-asset-or-module.md` § "When `apply.sh` Needs Changes" for guidance.
+
+If more than one placement is reasonable, present the options briefly with a recommendation
+and let the user choose before editing.
+
+## 5. Implement the change
+
+Match the style of the existing modules.
+Formatting is enforced by nixfmt via the pre-commit hooks.
+
+For `scripts/apply.sh`, if changes are needed:
+
+- Use the `prepend_block_once` helper for wiring shared config into user-managed files.
+- Follow the existing marker pattern (`# >>> ISSL <name> >>>` / `# <<< ISSL <name> <<<`).
+
+## 6. Add or update tests
+
+Every module should have corresponding test coverage under `tests/`.
+
+Tests run in CI against a freshly applied environment
+(`.github/workflows/test-environment.yaml` sets `HOME_DIR`/`CONFIG_DIR` and runs `tests/run.sh`).
+Do not try to run them locally unless this machine has the shared environment applied;
+local validation is prek plus `nix flake check` (step 7).
+
+If a test file for this area already exists (e.g. `tests/test-<tool>.sh`), extend it.
+If not, create a new `tests/test-<tool>.sh` following the existing pattern:
+
+1. Copy the header from the closest existing test:
+   `set -Eeuo pipefail`, the required environment variable guards
+   (`HOME_DIR:?` always; `CONFIG_DIR:?` when inspecting deployed config or user-managed file wiring),
+   the `COMMON_DIR` fallback, and `nix_profile_bin="${home_dir}/.nix-profile/bin"`.
+   Then source `tests/lib.sh` for the `run_assert` helper
+   and the failure-reporting ERR trap (which needs the `-E` in `set -Eeuo pipefail`).
+2. Define assertion functions (e.g. `assert_<tool>_installation`, `assert_<tool>_config`).
+3. Call them via `run_assert` in a `main` function.
+4. Make the script executable.
+5. Register the new test script in `tests/run.sh` by adding its name to the loop list.
+
+For a module imported conditionally (like `zsh.nix`),
+gate its assertions on the corresponding environment variable
+inside the relevant test script (see `ISSL_ENABLE_ZSH` in `test-shell.sh`)
+instead of adding a separate unconditional script.
+
+Common assertion patterns:
+
+- **Tool installation**: check `test -x "${nix_profile_bin}/<binary>"`
+  and verify `command -v` resolves to the Nix profile path.
+- **Asset deployment**: use `cmp` to verify the deployed file matches the source under `assets/`.
+- **Config wiring**: use `grep -Fq` to check that include or source lines
+  are present in user-managed files.
+
+## 7. Validate
+
+Run validation in this order:
+
+1. Run `prek run --files <changed files> --skip no-commit-to-branch` and fix what it reports.
+   If `prek` is not on PATH, use `uvx prek` instead.
+2. With Nix, run `nix flake check --show-trace`.
+   This builds the activation packages and catches both Nix evaluation errors and build failures.
+
+## 8. Wrap up
+
+Summarize what was changed, what was validated, and what was skipped.
+
+If the change affects contributor workflow or user-visible setup behavior,
+update the relevant documentation under `docs/` as part of this task
+(see `docs/92-updating-or-adding-an-asset-or-module.md` § "Documentation Updates").
+
+If the user later asks for a commit or PR,
+follow the Conventional Commits format described in `docs/93-contribution-guidelines.md`,
+and suggest an appropriate version bump label (`update::major`, `update::minor`, or `update::patch`)
+for the pull request.
+Leave all changes uncommitted until then.

--- a/.agents/skills/develop/SKILL.md
+++ b/.agents/skills/develop/SKILL.md
@@ -54,8 +54,11 @@ For a new tool:
 
 - Look the package up in nixpkgs at the pinned revision:
   read the `nixpkgs` entry's `locked.rev` from `flake.lock` and run `nix search github:NixOS/nixpkgs/<rev> <name>`.
-- Unfree packages are not enabled in this flake.
-  Adding one requires a flake change and an explicit yes from the user.
+- `home-modules/nix.nix` sets `nixpkgs.config.allowUnfree = true`,
+  so an unfree package can be added without a flake change.
+  Because that setting also applies to every personal config repository importing this one,
+  check the package's license terms and get an explicit yes from the user before adding one,
+  and state in the pull request why it is worth distributing to all users under those terms.
 - If the package is not in nixpkgs, report honestly and let the user decide.
   Never add flake inputs or overlays without an explicit yes.
 
@@ -137,8 +140,7 @@ Common assertion patterns:
 - **Tool installation**: check `test -x "${nix_profile_bin}/<binary>"`
   and verify `command -v` resolves to the Nix profile path.
 - **Asset deployment**: use `cmp` to verify the deployed file matches the source under `assets/`.
-- **Config wiring**: use `grep -Fq` to check that include or source lines
-  are present in user-managed files.
+- **Config wiring**: use `grep -Fq` to check that include or source lines are present in user-managed files.
 
 ## 7. Validate
 

--- a/.agents/skills/develop/SKILL.md
+++ b/.agents/skills/develop/SKILL.md
@@ -53,13 +53,7 @@ If there is already a related module or asset, update it rather than creating a 
 For a new tool:
 
 - Look the package up in nixpkgs at the pinned revision:
-  read the `nixpkgs` entry's `locked.rev` from `flake.lock`
-  and run `nix search github:NixOS/nixpkgs/<rev> <name>`.
-- Check whether Home Manager has a matching module (`programs.<tool>` or `services.<tool>`)
-  to understand available options — but see step 4 for why this repo does not use them directly.
-  On a machine with the environment applied,
-  `man home-configuration.nix` documents the installed version and is the source of truth;
-  otherwise use the Home Manager manual for the matching release.
+  read the `nixpkgs` entry's `locked.rev` from `flake.lock` and run `nix search github:NixOS/nixpkgs/<rev> <name>`.
 - Unfree packages are not enabled in this flake.
   Adding one requires a flake change and an explicit yes from the user.
 - If the package is not in nixpkgs, report honestly and let the user decide.

--- a/.claude/skills/develop
+++ b/.claude/skills/develop
@@ -1,0 +1,1 @@
+../../.agents/skills/develop

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ For more details, see the [User Guide](docs/10-user-guide.md).
 
 See [Developer Guide](docs/90-developer-guide.md).
 
+This repository ships a skill for coding agents that assists development;
+see [agent skill](docs/92-updating-or-adding-an-asset-or-module.md#agent-skill).
+
 ## License
 
 Licensed under either of [MIT license](LICENSE-MIT) or [Apache License, Version 2.0](LICENSE-APACHE) at your option.

--- a/docs/92-updating-or-adding-an-asset-or-module.md
+++ b/docs/92-updating-or-adding-an-asset-or-module.md
@@ -114,6 +114,16 @@ In practice, this usually means adding include blocks or source commands to user
 Validate a change with Nix in two steps:
 first confirm that it evaluates and builds, then inspect what it actually produces.
 
+Nix reads this repository through Git, so stage a new file before you validate:
+
+```console
+git add -N <new files>
+```
+
+This records an intent to add and creates no commit.
+Without it, a new module fails to evaluate because Nix does not see the file,
+and a new test is silently left out.
+
 1. Run the checks:
 
    ```console

--- a/docs/92-updating-or-adding-an-asset-or-module.md
+++ b/docs/92-updating-or-adding-an-asset-or-module.md
@@ -2,6 +2,19 @@
 
 This page explains the usual workflow for updating or adding a shared asset or module in this repository.
 
+## Agent Skill
+
+This repository ships a `develop` skill for coding agents that support [Agent Skills](https://agentskills.io)
+(e.g. Codex or Claude Code).
+Invoke it with `$develop` in Codex or `/develop` in Claude Code.
+
+It assists the workflow on this page interactively —
+from checking what already exists and researching nixpkgs
+to editing the modules and assets, extending the tests, and validating the result.
+State what you want when invoking it (e.g. `$develop add lazygit`).
+
+It leaves every change uncommitted, so you review the result before committing it yourself.
+
 ## Updating or Adding an Asset
 
 Changes to `assets/` are needed when the shared configuration files themselves should change.


### PR DESCRIPTION
Add a `develop` skill under `.agents/skills/`, with a `.claude/skills/develop` symlink so Claude Code picks it up.

- Guides an agent through a single change to the shared environment: understand the request, check what already exists, research the package, decide where the change goes, implement, add tests, validate, wrap up.
- Encodes the conventions of the developer docs, in particular the module and asset placement rules, the `~/.config/issl/` deployment convention, and the test script pattern under `tests/`.
- Points at `docs/92-updating-or-adding-an-asset-or-module.md` and `docs/93-contribution-guidelines.md` rather than restating them, so the docs stay the single source of truth.
- Keeps the agent from touching a real home environment: validation is prek plus `nix flake check` and a build of the activation packages, and all changes are left uncommitted.
