### PR TITLE
feat: install linters and formatters

### DIFF
--- a/home-modules/docker.nix
+++ b/home-modules/docker.nix
@@ -26,5 +26,6 @@ in
     dockerClient
     dockerCompose
     pkgs.docker-buildx
+    pkgs.hadolint
   ];
 }

--- a/home-modules/git.nix
+++ b/home-modules/git.nix
@@ -4,6 +4,8 @@
   home.packages = [
     pkgs.git
     pkgs.gh
+    pkgs.actionlint
+    pkgs.zizmor
   ];
 
   xdg.configFile."issl/git/.gitconfig".source = ../assets/git/.gitconfig;

--- a/home-modules/nix.nix
+++ b/home-modules/nix.nix
@@ -1,7 +1,13 @@
-_:
+{ pkgs, ... }:
 
 {
   nixpkgs.config.allowUnfree = true;
+
+  home.packages = [
+    pkgs.deadnix
+    pkgs.nixfmt
+    pkgs.statix
+  ];
 
   xdg.configFile."issl/nix/nix.conf".source = ../assets/nix/nix.conf;
 

--- a/home-modules/shell.nix
+++ b/home-modules/shell.nix
@@ -5,6 +5,8 @@
     pkgs.bash-completion
     pkgs.colordiff
     pkgs.coreutils
+    pkgs.shellcheck
+    pkgs.shfmt
   ];
 
   xdg.configFile = {

--- a/home-modules/typst.nix
+++ b/home-modules/typst.nix
@@ -1,5 +1,8 @@
 { pkgs, ... }:
 
 {
-  home.packages = [ pkgs.typst ];
+  home.packages = [
+    pkgs.typst
+    pkgs.typstyle
+  ];
 }

--- a/tests/test-docker.sh
+++ b/tests/test-docker.sh
@@ -38,12 +38,19 @@ assert_docker_buildx_installation() {
   docker buildx version
 }
 
+assert_hadolint_installation() {
+  test -x "${nix_profile_bin}/hadolint"
+  test "$(command -v hadolint)" = "${nix_profile_bin}/hadolint"
+  hadolint --version
+}
+
 main() {
   run_assert assert_docker_client_installation
   run_assert assert_docker_client_plugin_dirs_wrapper
   run_assert assert_docker_compose_installation
   run_assert assert_docker_compose_plugin_dirs_wrapper
   run_assert assert_docker_buildx_installation
+  run_assert assert_hadolint_installation
 }
 
 main "$@"

--- a/tests/test-git.sh
+++ b/tests/test-git.sh
@@ -21,6 +21,18 @@ assert_gh_installation() {
   gh --version
 }
 
+assert_actionlint_installation() {
+  test -x "${nix_profile_bin}/actionlint"
+  test "$(command -v actionlint)" = "${nix_profile_bin}/actionlint"
+  actionlint --version
+}
+
+assert_zizmor_installation() {
+  test -x "${nix_profile_bin}/zizmor"
+  test "$(command -v zizmor)" = "${nix_profile_bin}/zizmor"
+  zizmor --version
+}
+
 assert_shared_git_config() {
   cmp "${common_dir}/assets/git/.gitconfig" "${config_dir}/issl/git/.gitconfig"
 }
@@ -55,6 +67,8 @@ assert_git_identity() {
 main() {
   run_assert assert_git_installation
   run_assert assert_gh_installation
+  run_assert assert_actionlint_installation
+  run_assert assert_zizmor_installation
   run_assert assert_shared_git_config
   run_assert assert_global_git_include
   run_assert assert_git_identity

--- a/tests/test-nix.sh
+++ b/tests/test-nix.sh
@@ -47,7 +47,7 @@ assert_nixfmt_installation() {
 assert_statix_installation() {
   test -x "${nix_profile_bin}/statix"
   test "$(command -v statix)" = "${nix_profile_bin}/statix"
-  statix --version
+  statix --help
 }
 
 assert_deadnix_installation() {

--- a/tests/test-nix.sh
+++ b/tests/test-nix.sh
@@ -38,12 +38,33 @@ assert_home_manager_installation() {
   home-manager --version
 }
 
+assert_nixfmt_installation() {
+  test -x "${nix_profile_bin}/nixfmt"
+  test "$(command -v nixfmt)" = "${nix_profile_bin}/nixfmt"
+  nixfmt --version
+}
+
+assert_statix_installation() {
+  test -x "${nix_profile_bin}/statix"
+  test "$(command -v statix)" = "${nix_profile_bin}/statix"
+  statix --version
+}
+
+assert_deadnix_installation() {
+  test -x "${nix_profile_bin}/deadnix"
+  test "$(command -v deadnix)" = "${nix_profile_bin}/deadnix"
+  deadnix --version
+}
+
 main() {
   run_assert assert_nix_installation
   run_assert assert_shared_nix_config
   run_assert assert_nix_conf_include
   run_assert assert_nix_command_available_without_extra_flags
   run_assert assert_home_manager_installation
+  run_assert assert_nixfmt_installation
+  run_assert assert_statix_installation
+  run_assert assert_deadnix_installation
 }
 
 main "$@"

--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -78,6 +78,18 @@ assert_shared_shell_tools() {
   dircolors --version
 }
 
+assert_shellcheck_installation() {
+  test -x "${nix_profile_bin}/shellcheck"
+  test "$(command -v shellcheck)" = "${nix_profile_bin}/shellcheck"
+  shellcheck --version
+}
+
+assert_shfmt_installation() {
+  test -x "${nix_profile_bin}/shfmt"
+  test "$(command -v shfmt)" = "${nix_profile_bin}/shfmt"
+  shfmt --version
+}
+
 assert_zsh_enabled() {
   test -x "${nix_profile_bin}/zsh"
   test "$(command -v zsh)" = "${nix_profile_bin}/zsh"
@@ -125,6 +137,8 @@ main() {
   run_assert assert_bash_startup_is_loaded
   run_assert assert_profile_not_shadowed_by_bash_profile
   run_assert assert_shared_shell_tools
+  run_assert assert_shellcheck_installation
+  run_assert assert_shfmt_installation
 
   if [ "${issl_enable_zsh}" = "1" ]; then
     run_assert assert_zsh_enabled

--- a/tests/test-typst.sh
+++ b/tests/test-typst.sh
@@ -14,8 +14,15 @@ assert_typst_installation() {
   typst --version
 }
 
+assert_typstyle_installation() {
+  test -x "${nix_profile_bin}/typstyle"
+  test "$(command -v typstyle)" = "${nix_profile_bin}/typstyle"
+  typstyle --version
+}
+
 main() {
   run_assert assert_typst_installation
+  run_assert assert_typstyle_installation
 }
 
 main "$@"


### PR DESCRIPTION
Add the linters and formatters that the shared pre-commit baseline does not cover, so they are available from the command line in any repository.

- `shellcheck`, `shfmt` for shell scripts
- `nixfmt`, `statix`, `deadnix` for Nix
- `actionlint`, `zizmor` for GitHub Actions workflows
- `typstyle` for Typst
- `hadolint` for Dockerfiles

Each tool goes into the module that already covers its area, and the corresponding test script asserts its installation.
`home-modules/nix.nix` gains a `pkgs` argument because it had no `home.packages` before.

Closes #433
