### PR TITLE
feat(rust): install cargo tooling for testing, coverage and auditing

### DIFF
--- a/home-modules/rust.nix
+++ b/home-modules/rust.nix
@@ -2,8 +2,13 @@
 
 {
   home.packages = [
-    pkgs.cargo-about
     pkgs.rustup
+    pkgs.cargo-about
+    pkgs.cargo-deny
+    pkgs.cargo-hack
+    pkgs.cargo-llvm-cov
+    pkgs.cargo-nextest
+    pkgs.cargo-dist
   ];
 
   xdg.configFile."issl/rust/config.toml".source = ../assets/rust/config.toml;

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -10,16 +10,15 @@ export RUSTUP_HOME="${home_dir}/.rustup"
 # shellcheck source=tests/lib.sh
 source "${common_dir}/tests/lib.sh"
 
-assert_cargo_about_installation() {
-  test -x "${nix_profile_bin}/cargo-about"
-  test "$(command -v cargo-about)" = "${nix_profile_bin}/cargo-about"
-  cargo-about --version
-}
-
 assert_rustup_installation() {
   test -x "${nix_profile_bin}/rustup"
   test "$(command -v rustup)" = "${nix_profile_bin}/rustup"
   rustup --version
+}
+
+assert_rustc_installation() {
+  command -v rustc >/dev/null 2>&1
+  rustc --version
 }
 
 assert_cargo_installation() {
@@ -27,9 +26,40 @@ assert_cargo_installation() {
   cargo --version
 }
 
-assert_rustc_installation() {
-  command -v rustc >/dev/null 2>&1
-  rustc --version
+assert_cargo_about_installation() {
+  test -x "${nix_profile_bin}/cargo-about"
+  test "$(command -v cargo-about)" = "${nix_profile_bin}/cargo-about"
+  cargo about --version
+}
+
+assert_cargo_deny_installation() {
+  test -x "${nix_profile_bin}/cargo-deny"
+  test "$(command -v cargo-deny)" = "${nix_profile_bin}/cargo-deny"
+  cargo deny --version
+}
+
+assert_cargo_hack_installation() {
+  test -x "${nix_profile_bin}/cargo-hack"
+  test "$(command -v cargo-hack)" = "${nix_profile_bin}/cargo-hack"
+  cargo hack --version
+}
+
+assert_cargo_llvm_cov_installation() {
+  test -x "${nix_profile_bin}/cargo-llvm-cov"
+  test "$(command -v cargo-llvm-cov)" = "${nix_profile_bin}/cargo-llvm-cov"
+  cargo llvm-cov --version
+}
+
+assert_cargo_nextest_installation() {
+  test -x "${nix_profile_bin}/cargo-nextest"
+  test "$(command -v cargo-nextest)" = "${nix_profile_bin}/cargo-nextest"
+  cargo nextest --version
+}
+
+assert_dist_installation() {
+  test -x "${nix_profile_bin}/dist"
+  test "$(command -v dist)" = "${nix_profile_bin}/dist"
+  dist --version
 }
 
 assert_default_toolchain_stable() {
@@ -48,10 +78,15 @@ assert_cargo_config_include() {
 }
 
 main() {
-  run_assert assert_cargo_about_installation
   run_assert assert_rustup_installation
-  run_assert assert_cargo_installation
   run_assert assert_rustc_installation
+  run_assert assert_cargo_installation
+  run_assert assert_cargo_about_installation
+  run_assert assert_cargo_deny_installation
+  run_assert assert_cargo_hack_installation
+  run_assert assert_cargo_llvm_cov_installation
+  run_assert assert_cargo_nextest_installation
+  run_assert assert_dist_installation
   run_assert assert_default_toolchain_stable
   run_assert assert_shared_rust_config_asset
   run_assert assert_cargo_config_include


### PR DESCRIPTION
Add the Rust tools that complement what the rustup toolchain already provides (`rustfmt` and `clippy` come with the default profile), so they are available from the command line without a per-project install.

- `cargo-nextest` for running tests
- `cargo-llvm-cov` for coverage
- `cargo-deny` for dependency licenses and advisories, alongside the existing `cargo-about`
- `cargo-hack` for MSRV and feature-combination checks
- `cargo-dist`, which ships a single `dist` binary, for release automation

`cargo-llvm-cov` needs the `llvm-tools` rustup component, which is not part of the default profile. It installs the component on its own on first use, so no activation or environment change is needed here.

Assertions invoke each tool the way it is actually used, as a cargo subcommand, which also covers cargo being able to resolve it from `PATH`. `dist` keeps its plain invocation because the rename away from `cargo-dist` means `cargo dist` no longer resolves. The existing `cargo-about` assertion was switched to the same form for consistency.

Closes #434
