### PR TITLE
ci: run the Nix formatter and linters from the locked nixpkgs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,10 +203,10 @@ jobs:
         run: xargs -0 nix fmt -- --check < "${NIX_FILES}"
 
       - name: Run deadnix
-        run: nix run nixpkgs#deadnix -- --fail .
+        run: nix run --inputs-from . nixpkgs#deadnix -- --fail .
 
       - name: Run statix
-        run: nix run nixpkgs#statix -- check .
+        run: nix run --inputs-from . nixpkgs#statix -- check .
 
       - name: Run flake check
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,11 +202,11 @@ jobs:
           NIX_FILES: ${{ steps.nix-files.outputs.nix_files }}
         run: xargs -0 nix fmt -- --check < "${NIX_FILES}"
 
-      - name: Run statix
-        run: nix run nixpkgs#statix -- check .
-
       - name: Run deadnix
         run: nix run nixpkgs#deadnix -- --fail .
+
+      - name: Run statix
+        run: nix run nixpkgs#statix -- check .
 
       - name: Run flake check
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,20 @@ repos:
     hooks:
       - id: nixfmt-nix
 
+  - repo: https://github.com/astro/deadnix
+    rev: 67e5094c79b81b3084ababac4c81f22c26e11df5  # frozen: v1.3.1
+    hooks:
+      - id: deadnix
+
+  - repo: local
+    hooks:
+      - id: statix
+        name: statix
+        entry: nix run nixpkgs#statix -- check
+        language: system
+        files: \.nix$
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 2700fd5671c633760d912769c041bfcde2b9a01b  # frozen: v0.15.22
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,14 @@
 default_stages: [pre-commit]
 
 repos:
-  - repo: https://github.com/NixOS/nixfmt
-    rev: 7cad8663932db4519d4c5b623becdcda655cef7c  # frozen: v1.4.0
-    hooks:
-      - id: nixfmt-nix
-
   - repo: local
     hooks:
+      - id: nixfmt
+        name: nixfmt
+        entry: nix fmt --
+        language: system
+        files: \.nix$
+
       - id: deadnix
         name: deadnix
         entry: nix run --inputs-from . nixpkgs#deadnix -- --fail .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,16 +7,18 @@ repos:
     hooks:
       - id: nixfmt-nix
 
-  - repo: https://github.com/astro/deadnix
-    rev: 67e5094c79b81b3084ababac4c81f22c26e11df5  # frozen: v1.3.1
-    hooks:
-      - id: deadnix
-
   - repo: local
     hooks:
+      - id: deadnix
+        name: deadnix
+        entry: nix run --inputs-from . nixpkgs#deadnix -- --fail .
+        language: system
+        files: \.nix$
+        pass_filenames: false
+
       - id: statix
         name: statix
-        entry: nix run nixpkgs#statix -- check
+        entry: nix run --inputs-from . nixpkgs#statix -- check .
         language: system
         files: \.nix$
         pass_filenames: false

--- a/docs/92-updating-or-adding-an-asset-or-module.md
+++ b/docs/92-updating-or-adding-an-asset-or-module.md
@@ -115,7 +115,7 @@ Validate a change in three steps:
 first run the pre-commit hooks, then confirm that it evaluates and builds,
 and finally inspect what it actually produces.
 
-Both the hooks and Nix read this repository through Git, so stage a new file before you validate:
+Nix reads this repository through Git, so stage a new file before you validate:
 
 ```console
 git add -N <new files>
@@ -131,8 +131,8 @@ and a new test is silently left out.
    prek run --files <changed files>
    ```
 
-   This formats the changed files and runs the linters on them.
-   For Nix files, that means nixfmt, deadnix, and statix.
+   This applies the formatters and the linters to the changed files.
+   For Nix files, nixfmt formats the changed files, while deadnix and statix check the whole repository.
    See [Contribution Guidelines](93-contribution-guidelines.md) for how to install the hooks.
 
 2. Run the checks:

--- a/docs/92-updating-or-adding-an-asset-or-module.md
+++ b/docs/92-updating-or-adding-an-asset-or-module.md
@@ -111,10 +111,11 @@ In practice, this usually means adding include blocks or source commands to user
 
 ## Validating Changes
 
-Validate a change with Nix in two steps:
-first confirm that it evaluates and builds, then inspect what it actually produces.
+Validate a change in three steps:
+first run the pre-commit hooks, then confirm that it evaluates and builds,
+and finally inspect what it actually produces.
 
-Nix reads this repository through Git, so stage a new file before you validate:
+Both the hooks and Nix read this repository through Git, so stage a new file before you validate:
 
 ```console
 git add -N <new files>
@@ -124,7 +125,17 @@ This records an intent to add and creates no commit.
 Without it, a new module fails to evaluate because Nix does not see the file,
 and a new test is silently left out.
 
-1. Run the checks:
+1. Run the pre-commit hooks:
+
+   ```console
+   prek run --files <changed files>
+   ```
+
+   This formats the changed files and runs the linters on them.
+   For Nix files, that means nixfmt, deadnix, and statix.
+   See [Contribution Guidelines](93-contribution-guidelines.md) for how to install the hooks.
+
+2. Run the checks:
 
    ```console
    nix flake check --show-trace
@@ -133,7 +144,7 @@ and a new test is silently left out.
    This builds the activation packages for both the Bash-only and the Zsh configuration,
    and catches Nix evaluation errors and build failures.
 
-2. Build the activation packages to inspect the result:
+3. Build the activation packages to inspect the result:
 
    ```console
    nix build .#checks.x86_64-linux.home --out-link result-home


### PR DESCRIPTION
statix and deadnix were the only Nix checks in CI without a pre-commit counterpart, so a change could pass the hooks locally and still fail CI. Adding them surfaced a second problem: nothing tied the tools the hooks run to the ones CI runs.

- Run nixfmt, deadnix, and statix as pre-commit hooks, all resolved from the locked `nixpkgs`: nixfmt through `nix fmt`, so it is the flake formatter CI checks against, and the two linters through `nix run --inputs-from .`.
- `nix run nixpkgs#...` resolves through the flake registry, so it runs whichever revision a machine happens to point at. The upstream `nixfmt-nix` hook is such a call as well, which means its pinned revision froze the hook definition and not the formatter. For statix the registry and the locked input currently differ by two months of upstream changes.
- Resolve statix and deadnix from the same lock file in CI, and list the Nix checks in the same order as the hooks.
- Document the pre-commit hook run as the first validation step in the developer docs.
