### PR TITLE
chore: use pkgs.nixfmt instead of deprecated alias

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
         };
       };
 
-      formatter = forAllSystems (system: (mkPkgs system).nixfmt-rfc-style);
+      formatter = forAllSystems (system: (mkPkgs system).nixfmt);
 
       checks = forAllSystems (system: {
         home =


### PR DESCRIPTION
`pkgs.nixfmt-rfc-style` is now a deprecated alias of `pkgs.nixfmt` in nixpkgs, and evaluating it emits a warning on the pinned nixpkgs 26.05:

```
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
```

- Point `formatter` at `pkgs.nixfmt` instead

The two attributes resolve to the same derivation (nixfmt 1.3.1), so formatting behavior is unchanged.
This also matches `home-modules/nix.nix`, which already uses `pkgs.nixfmt`.
