### PR TITLE
ci(ruff): check Python formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,7 @@ jobs:
               - .yamllint.yaml
             python:
               - '**/*.py'
+              - '**/*.md'
               - pyproject.toml
               - .python-version
               - uv.lock
@@ -595,6 +596,20 @@ jobs:
             exit $ruff_rc
           fi
           exit $reviewdog_rc
+
+      - name: Format Python
+        run: uvx --from "ruff==0.16.0" ruff format .
+
+      - name: Suggest Python format changes (reviewdog)
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-suggester@2558ba17e65a9039e73764a73009fc05fef28a46 # v1.24.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tool_name: ruff-format
+          cleanup: 'false'
+
+      - name: Check Python format
+        run: git diff --exit-code
 
   check-prek:
     name: Check prek


### PR DESCRIPTION
CI only ran `ruff check`, so formatting violations surfaced solely through the prek job.
The `lint-python` job now formats in place and lets reviewdog turn the resulting diff into suggested changes on pull requests, mirroring how the `lint-toml` job already handles `tombi format`.

`ruff format` reformats Python code blocks in Markdown as of ruff 0.16, so `**/*.md` joins the `python` change filter — the filter tracks Python code and its configuration, wherever that code lives.
