### PR TITLE
ci(ruff): report ruff findings outside the pull request diff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -589,6 +589,7 @@ jobs:
               -f=rdjson \
               -name=ruff \
               -reporter=github-pr-review \
+              -filter-mode=nofilter \
               -fail-level=warning \
               -tee || reviewdog_rc=$?
           if [ $ruff_rc -ne 0 ] && [ ! -s /tmp/ruff-report.json ]; then

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,3 +2,6 @@ required-version = ">=0.16"
 target-version = "py314"
 line-length = 120
 indent-width = 4
+
+[lint]
+extend-select = ["TRY"]

--- a/assets/python/pythonrc.py
+++ b/assets/python/pythonrc.py
@@ -118,7 +118,7 @@ _ensure_history_dir()
 if not _will_use_pyrepl():
     _enable_completion()
     _set_colored_prompts()
-    if sys.version_info < (3, 13):  # noqa: UP036
+    if sys.version_info < (3, 13):
         _enable_history()
     elif _is_libedit():
         _redirect_history_for_libedit()


### PR DESCRIPTION
Draft: opened to observe how reviewdog behaves, not ready to merge.

reviewdog filters by added and modified lines by default, so a finding in a file the pull request does not touch is discarded and `-fail-level` never fires.
Rules that begin applying to existing code — the ruff 0.16 default rule set expansion being the recent example — therefore pass the `Lint Python` job and are caught only by `check-prek`.
`-filter-mode=nofilter` reports every finding and counts it towards the exit code.

The GitHub review API cannot place a comment outside the diff, so reviewdog falls back to a GitHub Actions annotation for those findings while in-diff findings stay inline review comments.

The second commit enables `TRY` temporarily and must be dropped before merging.
It produces two findings, both in files this branch does not touch:

- `assets/python/pythonrc.py:19` `TRY300`
- `tests/pty-driver.py:16` `TRY003`

What to look for once CI finishes:

- `Lint Python` fails rather than passing green.
- Both findings appear as annotations reachable from the checks tab.
- `check-prek` also fails, which is expected while the temporary commit is in place.
